### PR TITLE
Add `unrolled_enumerate` and `unrolled_applyat`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,7 @@
 name = "UnrolledUtilities"
 uuid = "0fe1646c-419e-43be-ac14-22321958931b"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.1"
-
-[deps]
+version = "0.1.2"
 
 [compat]
 julia = "1.10"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,6 +8,8 @@ A collection of generated functions in which all loops are unrolled and inlined:
 - `unrolled_reduce(op, itr; [init])`: similar to `reduce`
 - `unrolled_mapreduce(f, op, itrs...; [init])`: similar to `mapreduce`
 - `unrolled_zip(itrs...)`: similar to `zip`
+- `unrolled_enumerate(itrs...)`: similar to `enumerate`, but with the ability to
+  handle multiple iterators
 - `unrolled_in(item, itr)`: similar to `in`
 - `unrolled_unique(itr)`: similar to `unique`
 - `unrolled_filter(f, itr)`: similar to `filter`
@@ -16,10 +18,11 @@ A collection of generated functions in which all loops are unrolled and inlined:
 - `unrolled_flatten(itr)`: similar to `Iterators.flatten`
 - `unrolled_flatmap(f, itrs...)`: similar to `Iterators.flatmap`
 - `unrolled_product(itrs...)`: similar to `Iterators.product`
-- `unrolled_take(itr, ::Val{N})`: similar to `Iterators.take` or `itr[1:N]`, but
-  with `N` wrapped in a `Val`
-- `unrolled_drop(itr, ::Val{N})`: similar to `Iterators.drop` or
-  `itr[(N + 1):end]`, but with `N` wrapped in a `Val`
+- `unrolled_applyat(f, n, itrs...)`: similar to `f(map(itr -> itr[n], itrs)...)`
+- `unrolled_take(itr, ::Val{N})`: similar to `itr[1:N]` (and to
+  `Iterators.take`), but with `N` wrapped in a `Val`
+- `unrolled_drop(itr, ::Val{N})`: similar to `itr[(N + 1):end]` (and to
+  `Iterators.drop`), but with `N` wrapped in a `Val`
 
 These functions are guaranteed to be type-stable whenever they are given
 iterators with inferrable lengths and element types, including when


### PR DESCRIPTION
This PR adds 2 new unrolled functions, along with relevant tests and documentation:
  - `unrolled_enumerate`, which is similar to `enumerate` (but also able to handle multiple iterators at the same time)
  - `unrolled_applyat`, which applies a function to the item at a particular index of an iterator (or to the items at that index in multiple iterators)

The second function should be a simpler alternative to `TuplesOfNTuples.jl`.