### PR TITLE
Expand compat to Julia 1.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,10 @@
 name = "UnrolledUtilities"
 uuid = "0fe1646c-419e-43be-ac14-22321958931b"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.4"
+version = "0.1.5"
 
 [compat]
-julia = "1.10"
+julia = "1.9"
 StaticArrays = "1"
 
 [weakdeps]


### PR DESCRIPTION
The Julia 1.9 compatibility test in ClimaAtmos is currently failing in CliMA/ClimaAtmos.jl#3267 because this package is restricted to 1.10 and above. This PR extends the compatibility to 1.9 and above.