### PR TITLE
Fix GPU compilation bugs that required val_unrolled_reduce workaround

### DIFF
--- a/src/StaticBitVector.jl
+++ b/src/StaticBitVector.jl
@@ -34,8 +34,8 @@ end
         @inline
         first_index = n_bits_per_int * (int_index - 1) + 1
         unrolled_reduce(
-            StaticOneTo(min(n_bits_per_int, N - first_index + 1));
-            init = zero(U),
+            StaticOneTo(min(n_bits_per_int, N - first_index + 1)),
+            zero(U),
         ) do int, bit_index
             @inline
             bit_offset = bit_index - 1
@@ -93,15 +93,15 @@ end
     n_bits_per_int = 8 * sizeof(U)
     n_ints = cld(N, n_bits_per_int)
     ints = unrolled_accumulate(
-        StaticOneTo(n_ints);
-        init = (nothing, init),
-        transform = first,
+        StaticOneTo(n_ints),
+        (nothing, init),
+        first,
     ) do (_, init_value_for_new_int), int_index
         @inline
         first_index = n_bits_per_int * (int_index - 1) + 1
         unrolled_reduce(
-            StaticOneTo(min(n_bits_per_int, N - first_index + 1));
-            init = (zero(U), init_value_for_new_int),
+            StaticOneTo(min(n_bits_per_int, N - first_index + 1)),
+            (zero(U), init_value_for_new_int),
         ) do (int, prev_value), bit_index
             @inline
             bit_offset = bit_index - 1


### PR DESCRIPTION
After experimenting in CliMA/ClimaAtmos.jl#3313, I've found that two changes are needed to remove the `val_unrolled_reduce` workaround for GPUs: removal of internal function calls with keyword arguments and forced specialization on function arguments.

The first of these changes also seems to marginally decrease the amount of time and memory required for compilation of some unit tests, with the decrease most clearly noticeable in the `Very Long Iterators` comparison table. This confirms a long-standing suspicion that function calls with keyword arguments make compilation of low-level kernels more difficult.

I'm somewhat surprised that the second of these changes is necessary, given that everything is already inlined and it makes no observable difference for compilation on CPUs. Just to be on the safe side, though, I've added forced specialization for every function exported by this package.

Hopefully these changes will be enough to make UnrolledUtilities fully type-stable on GPUs.