### PR TITLE
Remove no longer necessary val_unrolled_reduce workaround

### DIFF
--- a/src/UnrolledUtilities.jl
+++ b/src/UnrolledUtilities.jl
@@ -63,15 +63,6 @@ include("generatively_unrolled_functions.jl")
 @inline unrolled_reduce(op::O, itr; init = NoInit()) where {O} =
     unrolled_reduce(op, itr, init)
 
-# TODO: Figure out why unrolled_reduce(op, Val(N), init) compiles faster than
-# unrolled_reduce(op, StaticOneTo(N), init) for the non-orographic gravity wave
-# parametrization test in ClimaAtmos, to the point where the StaticOneTo version
-# completely hangs while the Val version compiles in only a few seconds.
-@inline unrolled_reduce(op::O, val_N::Val, init) where {O} =
-    val_N isa Val{0} && init isa NoInit ?
-    error("unrolled_reduce requires an init value for Val(0)") :
-    val_unrolled_reduce(op, val_N, init)
-
 @inline unrolled_mapreduce(f::F, op::O, itrs...; init = NoInit()) where {F, O} =
     unrolled_reduce(op, unrolled_map(f, itrs...), init)
 

--- a/src/generatively_unrolled_functions.jl
+++ b/src/generatively_unrolled_functions.jl
@@ -67,22 +67,3 @@ end
 end
 @inline gen_unrolled_accumulate(op, itr, init, transform) =
     _gen_unrolled_accumulate(Val(length(itr)), op, itr, init, transform)
-
-# TODO: The following is experimental and will likely be removed in the future.
-# For some reason, combining these two methods into one (or combining them with
-# the method for gen_unrolled_reduce defined above) causes compilation of the
-# non-orographic gravity wave parametrization test in ClimaAtmos to hang.
-# Wrapping the first method's result in a block and adding an inline annotation
-# also causes compilation to hang. Even using the assignment form of the first
-# method definition below (as opposed to the function syntax used here) causes
-# it to hang. This has not yet been replicated in a minimal working example.
-@generated function val_unrolled_reduce(op, ::Val{N}, init) where {N}
-    return foldl((:init, 1:N...)) do prev_op_expr, item_expr
-        :(op($prev_op_expr, $item_expr))
-    end
-end
-@generated val_unrolled_reduce(op, ::Val{N}, ::NoInit) where {N} = Expr(
-    :block,
-    Expr(:meta, :inline),
-    foldl((op_expr, item_expr) -> :(op($op_expr, $item_expr)), 1:N),
-)


### PR DESCRIPTION
This PR removes the method for `unrolled_reduce` that specialized on a `Val` as its input (instead of specializing on an iterator), along with the underlying definition of `val_unrolled_reduce`.

This workaround was previously required to avoid long compilation times in three of the CPU tests for the non-orographic gravity wave parametrization in ClimaAtmos. Since CliMA/ClimaAtmos.jl#3313 has isolated the specific aspect of `val_unrolled_reduce` that was allowing us to avoid long compilation times, this non-standard implementation of `unrolled_reduce` is no longer necessary.