### PR TITLE
Improve usability and performance

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -1,5 +1,4 @@
 name: CodeCov
-
 on:
   push:
     branches:
@@ -9,35 +8,20 @@ on:
   merge_group:
 
 jobs:
-  codecov:
+  test:
+    name: CodeCov
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Julia
-      uses: julia-actions/setup-julia@latest
-      with:
-        version: '1.10'
-
-    - name: Test with coverage
-      env:
-        JULIA_PROJECT: "@."
-      run: |
-        julia --project=@. -e 'using Pkg; Pkg.instantiate()'
-        julia --project=@. -e 'using Pkg; Pkg.test(coverage=true)'
-
-    - name: Generate coverage file
-      env:
-        JULIA_PROJECT: "@."
-      run: julia --project=@. -e 'using Pkg; Pkg.add("Coverage");
-                                  using Coverage;
-                                  LCOV.writefile("coverage-lcov.info", Codecov.process_folder())'
-      if: success()
-
-    - name: Submit coverage
-      uses: codecov/codecov-action@v3
-      with:
-        token: ${{secrets.CODECOV_TOKEN}}
-      if: success()
-
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: 1.11
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          test_args: 'fast_mode' # Testing with code coverage is very slow.
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v5
+        with:
+          file: lcov.info
+          token: ${{secrets.CODECOV_TOKEN}}

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.10'
+          version: '1.11'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: '1.10'
+        version: '1.11'
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,37 +16,17 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '~1.11.0-0'
+          - '1.11'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
-        exclude:
-          - version: '~1.11.0-0'
-            os: macOS-latest # JET crashes on one unit test and hangs on another
-          - version: '~1.11.0-0'
-            os: windows-latest # JET crashes on 3 unit tests
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
-        with:
-          file: lcov.info
+      - name: Run tests
+        run: julia --project -e 'using Pkg; Pkg.test(; coverage = false)'
+        # Using the julia-runtest action makes this more than 2 times slower.

--- a/.github/workflows/invalidations.yml
+++ b/.github/workflows/invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v1
       with:
-        version: '1.10' # JET and SnoopCompile do not yet support Julia 1.11
+        version: '1.11'
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnrolledUtilities"
 uuid = "0fe1646c-419e-43be-ac14-22321958931b"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [compat]
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 </picture>
 </h1>
 
-A toolkit for optimizing Julia code that uses statically sized iterators.
+Are you feeling type unstable? Struggling to compile code for GPUs? Do you find yourself with more allocations than FLOPS?
+
+Ask your developer if *UnrolledUtilities.jl* is right for you.
 
 |||
 |---------------------:|:----------------------------------------------|

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -29,14 +29,7 @@ following function:
 rec_unroll
 ```
 
-!!! tip "Tip"
-    Recursive loop unrolling can be enabled by redefining this function:
-
-    ```julia
-    rec_unroll(itr) = true
-    ```
-
-The default choice of generative unrolling is motivated by the benchmarks for
+The default choice for `rec_unroll` is motivated by the benchmarks for
 [Generative vs. Recursive Unrolling](@ref).
 
 ## Interface API
@@ -54,6 +47,7 @@ ConditionalOutputType
 output_promote_rule
 constructor_from_tuple
 empty_output
+StaticSequence
 ```
 
 ## How to Use the Interface
@@ -83,12 +77,12 @@ these steps:
           be implemented to construct an iterator of type `U` without first
           storing the iterator's contents in a `Tuple`:
             - `empty_output(U)`
-            - `unrolled_map_into(U, f, itr)`
-            - `unrolled_accumulate_into(U, op, itr, init, transform)`
             - `unrolled_push_into(U, itr, item)`
             - `unrolled_append_into(U, itr1, itr2)`
             - `unrolled_take_into(U, itr, val_N)`
             - `unrolled_drop_into(U, itr, val_N)`
+            - `unrolled_map_into(U, f, itr)`
+            - `unrolled_accumulate_into(U, op, itr, init, transform)`
 
 !!! note "Note"
     When a relevant method for the interface is not defined, unrolled functions

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,8 +15,11 @@ inefficiently. For example, the standard libary function `in` performs worse
 than this package's `unrolled_in` for `Tuple`s with elements of different types:
 
 ```@repl inference_test
-@allocated () in ((1, 2), (1, 2, 3))
-@allocated unrolled_in((), ((1, 2), (1, 2, 3)))
+nonuniform_itr = ((1, 2), (1, 2, 3));
+() in nonuniform_itr # hide
+@allocated () in nonuniform_itr
+unrolled_in((), nonuniform_itr) # hide
+@allocated unrolled_in((), nonuniform_itr)
 ```
 
 The [loop unrolling](https://en.wikipedia.org/wiki/Loop_unrolling) automatically
@@ -40,40 +43,64 @@ To find out more about loop unrolling and when it is useful, see the
 This package exports a number of analogues to functions from `Base` and
 `Base.Iterators`, each of which has been optimized for statically sized
 iterators (in terms of both performance and compilation time):
-- `unrolled_any(f, itr)`—similar to `any`
-- `unrolled_all(f, itr)`—similar to `all`
-- `unrolled_foreach(f, itrs...)`—similar to `foreach`
-- `unrolled_map(f, itrs...)`—similar to `map`
-- `unrolled_reduce(op, itr; [init])`—similar to `reduce`
-- `unrolled_mapreduce(f, op, itrs...; [init])`—similar to `mapreduce`
-- `unrolled_accumulate(op, itr; [init], [transform])`—similar to `accumulate`,
-  but with a `transform` that can be applied to every value in the output
 - `unrolled_push(itr, item)`—similar to `push!`, but non-mutating
-- `unrolled_append(itr1, itr2)`—similar to `append!`, but non-mutating
-- `unrolled_take(itr, ::Val{N})`—similar to `Iterators.take` (i.e., `itr[1:N]`),
-  but with `N` wrapped in a `Val`
-- `unrolled_drop(itr, ::Val{N})`—similar to `Iterators.drop` (i.e.,
-  `itr[(N + 1):end]`), but with `N` wrapped in a `Val`
+- `unrolled_append(itr, itrs...)`—similar to `append!`, but non-mutating
+- `unrolled_prepend(itr, itrs...)`—similar to `prepend!`, but non-mutating
+- `unrolled_map(f, itrs...)`—similar to `map`
+- `unrolled_any([f], itr)`—similar to `any`
+- `unrolled_all([f], itr)`—similar to `all`
+- `unrolled_foreach(f, itrs...)`—similar to `foreach`
+- `unrolled_reduce(op, itr; [init])`—similar to `reduce` (i.e., `foldl`)
+- `unrolled_mapreduce(f, op, itrs...; [init])`—similar to `mapreduce` (i.e.,
+  `mapfoldl`)
+- `unrolled_accumulate(op, itr; [init])`—similar to `accumulate`
 - `unrolled_in(item, itr)`—similar to `in`
-- `unrolled_unique(itr)`—similar to `unique`
+- `unrolled_unique([f], itr)`—similar to `unique`
+- `unrolled_allunique([f], itr)`—similar to `allunique`
+- `unrolled_allequal([f], itr)`—similar to `allequal`
+- `unrolled_sum([f], itr; [init])`—similar to `sum`, but with `init = 0` when
+  `itr` is empty
+- `unrolled_prod([f], itr; [init])`—similar to `prod`, but with `init = 1` when
+  `itr` is empty
+- `unrolled_cumsum([f], itr)`—similar to `cumsum`, but with an optional `f`
+- `unrolled_cumprod([f], itr)`—similar to `cumprod`, but with an optional `f`
+- `unrolled_count([f], itr)`—similar to `count`
+- `unrolled_maximum([f], itr)`—similar to `maximum`
+- `unrolled_minimum([f], itr)`—similar to `minimum`
+- `unrolled_extrema([f], itr)`—similar to `extrema`
+- `unrolled_findmax([f], itr)`—similar to `findmax`
+- `unrolled_findmin([f], itr)`—similar to `findmin`
+- `unrolled_argmax([f], itr)`—similar to `argmax`
+- `unrolled_argmin([f], itr)`—similar to `argmin`
+- `unrolled_findfirst([f], itr)`—similar to `findfirst`
+- `unrolled_findlast([f], itr)`—similar to `findlast`
 - `unrolled_filter(f, itr)`—similar to `filter`
 - `unrolled_flatten(itr)`—similar to `Iterators.flatten`
 - `unrolled_flatmap(f, itrs...)`—similar to `Iterators.flatmap`
 - `unrolled_product(itrs...)`—similar to `Iterators.product`
+- `unrolled_cycle(itr, ::Val{N})`—similar to `Iterators.cycle`, but with a
+  static value of `N`
+- `unrolled_partition(itr, ::Val{N})`—similar to `Iterators.partition`, but with
+  a static value of `N`
+- `unrolled_take(itr, ::Val{N})`—similar to `Iterators.take` (i.e., `itr[1:N]`),
+  but with a static value of `N`
+- `unrolled_drop(itr, ::Val{N})`—similar to `Iterators.drop` (i.e.,
+  `itr[(N + 1):end]`), but with a static value of `N`
 
-In addition, this package exports two functions that do not have public
-analogues in `Base` or `Base.Iterators`:
-- `unrolled_applyat(f, n, itrs...)`—similar to `f(itrs[1][n], itrs[2][n], ...)`,
-  but with a `Core.Const` index in every call to `getindex`
+In addition, this package exports several functions that do not have analogues
+in `Base` or `Base.Iterators`:
+- `unrolled_applyat(f, n, itrs...)`—similar to `f(itrs[1][n], itrs[2][n], ...)`
+- `unrolled_argfirst(f, itr)`—similar to `itr[findfirst(f, itr)]`
+- `unrolled_arglast(f, itr)`—similar to `itr[findlast(f, itr)]`
 - `unrolled_split(f, itr)`—similar to `(filter(f, itr), filter(!f, itr))`, but
   without duplicate calls to `f`
 
 These unrolled functions are compatible with the following types of iterators:
 - statically sized iterators from `Base` (e.g., `Tuple` and `NamedTuple`)
 - statically sized iterators from `StaticArrays` (e.g., `SVector` and `MVector`)
-- lazy iterators from `Base` (e.g., the results of `enumerate`, `zip`,
-  `Iterators.map`, and generator expressions) that are used as wrappers for
-  statically sized iterators
+- lazy iterators from `Base` (e.g., the results of generator expressions,
+  `Iterators.map`, `Iterators.reverse`, `enumerate`, and `zip`) that are used as
+  wrappers for statically sized iterators
 
 They are also compatible with two new types of statically sized iterators
 exported by this package:

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -4,6 +4,9 @@ CurrentModule = UnrolledUtilities
 
 ```@setup inference_test
 using UnrolledUtilities, InteractiveUtils, Test
+nonuniform_itr = ((1, 2), (1, 2, 3));
+nested_itr_of_depth_2 = ((1, 2), (3, 4));
+nested_itr_of_depth_3 = (((1,), (2,)), ((3,), (4,)));
 ```
 
 # When to Use UnrolledUtilities
@@ -48,23 +51,19 @@ Depth = 2:3
 
 ### Iterators with elements of different types
 
-- `in` has an intermediate type instability that triggers allocations for
-  nonuniform iterators:
+- `in`, `any`, `all`, `foreach`, and other functions in `Base` have intermediate
+  type instabilities that trigger allocations for nonuniform iterators:
 
   ```@repl inference_test
-  @allocated () in ((1, 2), (1, 2, 3))
-  @allocated unrolled_in((), ((1, 2), (1, 2, 3)))
-  ```
-
-- `any`, `all`, and `foreach` have intermediate type instabilities that trigger
-  allocations for nonuniform iterators with lengths greater than 32:
-
-  ```@repl inference_test
-  const nonuniform_itr_of_length_32 = (ntuple(Returns((1, 2)), 31)..., (1, 2, 3));
-  const nonuniform_itr_of_length_33 = (ntuple(Returns((1, 2)), 32)..., (1, 2, 3));
-  @allocated any(isempty, nonuniform_itr_of_length_32)
-  @allocated any(isempty, nonuniform_itr_of_length_33)
-  @allocated unrolled_any(isempty, nonuniform_itr_of_length_33)
+  nonuniform_itr = ((1, 2), (1, 2, 3));
+  () in nonuniform_itr # hide
+  @allocated () in nonuniform_itr
+  unrolled_in((), nonuniform_itr) # hide
+  @allocated unrolled_in((), nonuniform_itr)
+  any(isempty, nonuniform_itr) # hide
+  @allocated any(isempty, nonuniform_itr)
+  unrolled_any(isempty, nonuniform_itr) # hide
+  @allocated unrolled_any(isempty, nonuniform_itr)
   ```
 
 - `getindex` has an unstable return type for nonuniform iterators when given
@@ -78,16 +77,16 @@ Depth = 2:3
           length_sum += length(itr[n])
       end
   end
-  add_lengths(((1, 2), (1, 2, 3))) # hide
-  @allocated add_lengths(((1, 2), (1, 2, 3)))
+  add_lengths(nonuniform_itr) # hide
+  @allocated add_lengths(nonuniform_itr)
   function unrolled_add_lengths(itr)
       length_sum = 0
       for n in 1:length(itr)
           length_sum += unrolled_applyat(length, n, itr)
       end
   end
-  unrolled_add_lengths(((1, 2), (1, 2, 3))) # hide
-  @allocated unrolled_add_lengths(((1, 2), (1, 2, 3)))
+  unrolled_add_lengths(nonuniform_itr) # hide
+  @allocated unrolled_add_lengths(nonuniform_itr)
   ```
 
   !!! note "Note"
@@ -117,27 +116,30 @@ Depth = 2:3
   !!! tip "Tip"
       ##### *When should `getindex` be replaced with `unrolled_applyat`?*
 
-      The specific example above could be simplified by using `mapreduce`,
+      The specific example above can be simplified by using `unrolled_sum`,
       instead of using a `for`-loop in conjunction with `unrolled_applyat`:
 
-      ```@repl
-      @allocated mapreduce(length, +, ((1, 2), (1, 2, 3)))
+      ```@repl inference_test
+      nonuniform_itr = ((1, 2), (1, 2, 3));
+      unrolled_sum(length, nonuniform_itr) # hide
+      @allocated unrolled_sum(length, nonuniform_itr)
       ```
 
-      However, there are often situations in which it is not possible to
-      replace loops with function calls, like when those loops are parallelized
-      over CPU or GPU threads. Moreover, CUDA is unable to compile any kernels
-      with type instabilities that trigger allocations, so `unrolled_applyat` is
-      *required* in order to parallelize over nonuniform iterators on GPUs.
+      However, there are often situations in which loops cannot be replaced with
+      function calls, such as when the loops are parallelized over multiple
+      threads. For example, since CUDA is unable to compile kernels with type
+      instabilities, something like the switch instruction in `unrolled_applyat`
+      is *required* in order to parallelize over nonuniform iterators on GPUs.
 
 - For benchmarks that indicate performance improvements when using unrolled
   functions with nonuniform iterators, see [Isolated Unrolled Functions](@ref)
   and [Nested Unrolled Functions](@ref)
 
-### Reduction operations with non-constant return types
+### Reductions with intermediate values of different types
 
 - `reduce` and `accumulate` have unstable return types when the return type of
-  `op` is not constant, but only for iterator lengths greater than 32:
+  the reduction operator is not constant, but only for iterators with lengths
+  greater than 32:
 
   ```@repl inference_test
   Test.@inferred reduce(tuple, Tuple(1:32));
@@ -148,34 +150,66 @@ Depth = 2:3
 - For benchmarks that indicate performance improvements when using unrolled
   functions with nonuniform reductions, see [Isolated Unrolled Functions](@ref)
 
-### Operations with more than 2 levels of recursion
+### Functions with recursion during compilation
 
-- All functions in Julia have a default "recursion limit" of 2; unless this
-  limit is modified, it forces any function that recursively calls itself 2 or
-  more times to have an unstable return type:
+- Any function that recursively calls itself with different types of arguments
+  can trigger a compilation heuristic called the "recursion limit", which causes
+  the compiler to generate code with type instabilities and allocations
+  
+  - Before Julia 1.11, the default recursion limit applied to every function
+    with at least 3 levels of recursion during compilation, including relatively
+    simple functions like an analogue of `length` for nested `Tuple`s:
 
-  ```@repl inference_test
-  recursive_length(itr) =
-      eltype(itr) <: Tuple ? mapreduce(recursive_length, +, itr) : length(itr)
-  Test.@inferred recursive_length(((1, 2), (1, 2, 3)));
-  Test.@inferred recursive_length((((1,), (2,)), (1, 2, 3)));
-  unrolled_recursive_length(itr) =
-      eltype(itr) <: Tuple ?
-      unrolled_mapreduce(unrolled_recursive_length, +, itr) : length(itr)
-  Test.@inferred unrolled_recursive_length((((1,), (2,)), (1, 2, 3)));
-  ```
+    ```@repl inference_test
+    nested_itr_of_depth_2 = ((1, 2), (3, 4));
+    nested_itr_of_depth_3 = (((1,), (2,)), ((3,), (4,)));
+    recursive_length(itr) =
+        eltype(itr) <: Tuple ? sum(recursive_length, itr) : length(itr)
+    Test.@inferred recursive_length(nested_itr_of_depth_2);
+    Test.@inferred recursive_length(nested_itr_of_depth_3);
+    ```
+  
+  - As of Julia 1.11, the default recursion limit is no longer triggered for
+    this simple example, but still applies to more complex recursive functions:
+
+    ```@repl inference_test
+    recursive_sum_with_logs(itr) =
+        eltype(itr) <: Tuple ?
+        sum(recursive_sum_with_logs, itr) +
+        sum(log ∘ recursive_sum_with_logs, itr) :
+        sum(itr)
+    Test.@inferred recursive_sum_with_logs(nested_itr_of_depth_2);
+    Test.@inferred recursive_sum_with_logs(nested_itr_of_depth_3);
+    unrolled_recursive_sum_with_logs(itr) =
+        eltype(itr) <: Tuple ?
+        unrolled_sum(unrolled_recursive_sum_with_logs, itr) +
+        unrolled_sum(log ∘ unrolled_recursive_sum_with_logs, itr) :
+        unrolled_sum(itr)
+    Test.@inferred unrolled_recursive_sum_with_logs(nested_itr_of_depth_3);
+    ```
 
   !!! note "Note"
-      ##### *Is there any other way to avoid the default recursion limit?*
+      ##### *How can the default recursion limit be avoided?*
 
-      The default recursion limit applies to all functions defined in `Base` and
-      `Base.Iterators`, so those functions will have unstable return types for
-      more than 2 levels of recursion, even when all user-defined functions
-      passed to them have had their recursion limits disabled. It is also
-      impossible to modify the recursion limits of functions defined in `Base`
-      from external packages. This means that the only way to avoid the default
-      recursion limit is to not use certain functions from `Base`, and instead
-      to define alternatives without any recursion limits.
+      The recursion limit of any function `f` can be disabled by evaluating the
+      following code in the module where `f` is defined:
+
+      ```julia
+      @static if hasfield(Method, :recursion_relation)
+          for method in methods(f)
+              method.recursion_relation = Returns(true)
+          end
+      end
+      ```
+
+      However, the recursion limits of functions defined in `Base` cannot be
+      modified from any module outside of `Base`. Since the default limit
+      applies to all functions from `Base`, they can have unstable return types
+      whenever they need more than 2 levels of recursion for compilation, even
+      if the user-defined functions passed to them have no recursion limits. The
+      only way to avoid the default limit of a function from `Base` is to
+      replace it with a function whose limit has been disabled (such as an
+      analogous function from `UnrolledUtilities`).
 
 - For benchmarks that indicate performance improvements when using unrolled
   functions with recursive operations, see [Recursive Unrolled Functions](@ref)

--- a/src/StaticBitVector.jl
+++ b/src/StaticBitVector.jl
@@ -82,39 +82,6 @@ end
         Base.Fix1(generic_getindex, Iterators.map(f, itr)),
     )
 
-@inline function unrolled_accumulate_into(
-    ::Type{StaticBitVector{<:Any, U}},
-    op,
-    itr,
-    init,
-    transform,
-) where {U}
-    N = length(itr)
-    n_bits_per_int = 8 * sizeof(U)
-    n_ints = cld(N, n_bits_per_int)
-    ints = unrolled_accumulate(
-        StaticOneTo(n_ints),
-        (nothing, init),
-        first,
-    ) do (_, init_value_for_new_int), int_index
-        @inline
-        first_index = n_bits_per_int * (int_index - 1) + 1
-        unrolled_reduce(
-            StaticOneTo(min(n_bits_per_int, N - first_index + 1)),
-            (zero(U), init_value_for_new_int),
-        ) do (int, prev_value), bit_index
-            @inline
-            bit_offset = bit_index - 1
-            item = generic_getindex(itr, first_index + bit_offset)
-            new_value =
-                first_index + bit_offset == 1 && prev_value isa NoInit ?
-                item : op(prev_value, item)
-            (int | U(transform(new_value)::Bool) << bit_offset, new_value)
-        end
-    end
-    return StaticBitVector{N, U}(ints)
-end
-
 @inline function unrolled_push_into(
     ::Type{StaticBitVector{<:Any, U}},
     itr,
@@ -191,4 +158,36 @@ end
         end
     end
     return StaticBitVector{length(itr) - N, U}(ints)
+end
+
+@inline function unrolled_accumulate_into(
+    ::Type{StaticBitVector{<:Any, U}},
+    op,
+    itr,
+    init,
+) where {U}
+    N = length(itr)
+    n_bits_per_int = 8 * sizeof(U)
+    n_ints = cld(N, n_bits_per_int)
+    ints = unrolled_accumulate(
+        StaticOneTo(n_ints),
+        (nothing, init),
+        first,
+    ) do (_, init_value_for_new_int), int_index
+        @inline
+        first_index = n_bits_per_int * (int_index - 1) + 1
+        unrolled_reduce(
+            StaticOneTo(min(n_bits_per_int, N - first_index + 1)),
+            (zero(U), init_value_for_new_int),
+        ) do (int, prev_value), bit_index
+            @inline
+            bit_offset = bit_index - 1
+            item = generic_getindex(itr, first_index + bit_offset)
+            new_value =
+                first_index + bit_offset == 1 && prev_value isa NoInit ?
+                item : op(prev_value, item)
+            (int | U(new_value::Bool) << bit_offset, new_value)
+        end
+    end
+    return StaticBitVector{N, U}(ints)
 end

--- a/src/UnrolledUtilities.jl
+++ b/src/UnrolledUtilities.jl
@@ -1,45 +1,148 @@
 module UnrolledUtilities
 
-export unrolled_any,
+export StaticSequence,
+    StaticOneTo,
+    StaticBitVector,
+    unrolled_push,
+    unrolled_append,
+    unrolled_prepend,
+    unrolled_take,
+    unrolled_drop,
+    unrolled_map,
+    unrolled_any,
     unrolled_all,
     unrolled_foreach,
-    unrolled_map,
-    unrolled_applyat,
     unrolled_reduce,
     unrolled_mapreduce,
     unrolled_accumulate,
-    unrolled_push,
-    unrolled_append,
-    unrolled_take,
-    unrolled_drop,
+    unrolled_applyat,
     unrolled_in,
     unrolled_unique,
+    unrolled_allunique,
+    unrolled_allequal,
+    unrolled_sum,
+    unrolled_prod,
+    unrolled_cumsum,
+    unrolled_cumprod,
+    unrolled_count,
+    unrolled_maximum,
+    unrolled_minimum,
+    unrolled_extrema,
+    unrolled_findmax,
+    unrolled_findmin,
+    unrolled_argmax,
+    unrolled_argmin,
+    unrolled_findfirst,
+    unrolled_findlast,
+    unrolled_argfirst,
+    unrolled_arglast,
     unrolled_filter,
     unrolled_split,
     unrolled_flatten,
     unrolled_flatmap,
     unrolled_product,
-    StaticOneTo,
-    StaticBitVector
+    unrolled_cycle,
+    unrolled_partition
 
-struct NoInit end # Analogue of Base._InitialValue for reduction/accumulation.
+##
+## Internal types and functions
+##
 
 include("unrollable_iterator_interface.jl")
+
+# Analogue of the non-public Base._InitialValue for reduction and accumulation.
+struct NoInit end
+
+# Analogue of ∘, but with only one function argument and guaranteed inlining.
+# Base's ∘ leads to type instabilities in unit tests on Julia 1.10 and 1.11.
+@inline ⋅(f1::F1, f2::F2) where {F1, F2} = x -> (@inline f1(f2(x)))
+@inline ⋅(::Type{T}, f::F) where {T, F} = x -> (@inline T(f(x)))
+@inline ⋅(f::F, ::Type{T}) where {F, T} = x -> (@inline f(T(x)))
+@inline ⋅(::Type{T1}, ::Type{T2}) where {T1, T2} = x -> (@inline T1(T2(x)))
+
+##
+## Types with optimized methods for unrolled functions
+##
+
+"""
+    StaticSequence{N}
+
+Abstract type that can represent any iterable of constant length `N`. Subtypes
+include the low-storage data structures `StaticOneTo` and `StaticBitVector`,
+which have optimized methods for certain unrolled functions.
+"""
+abstract type StaticSequence{N} end
+
+@inline Base.length(::StaticSequence{N}) where {N} = N
+@inline Base.firstindex(::StaticSequence) = 1
+@inline Base.lastindex(itr::StaticSequence) = length(itr)
+@inline Base.getindex(itr::StaticSequence, n::Integer) =
+    generic_getindex(itr, n)
+@inline Base.iterate(itr::StaticSequence, n = 1) =
+    n > length(itr) ? nothing : (generic_getindex(itr, n), n + 1)
+@inline Base.iterate(
+    itr::Iterators.Reverse{<:StaticSequence},
+    n = length(itr),
+) = n < 1 ? nothing : (generic_getindex(itr.itr, n), n - 1)
+
+include("StaticOneTo.jl")
+include("StaticBitVector.jl")
+
+@inline static_range(itr) = StaticOneTo(length(itr))
+
+##
+## Functions unrolled using either Core.tuple or ntuple
+##
+
+@inline unrolled_push_into(output_type, itr, item) =
+    constructor_from_tuple(output_type)((itr..., item))
+@inline unrolled_push(itr, item) =
+    unrolled_push_into(inferred_output_type(itr), itr, item)
+@inline unrolled_push(itr, items...) =
+    unrolled_reduce(unrolled_push, items, itr)
+
+@inline unrolled_append_into(output_type, itr1, itr2) =
+    constructor_from_tuple(output_type)(
+        ntuple(Val(length(itr1) + length(itr2))) do n
+            @inline
+            n <= length(itr1) ? generic_getindex(itr1, n) :
+            generic_getindex(itr2, n - length(itr1))
+        end,
+    )
+@inline unrolled_append(itr1, itr2) =
+    unrolled_append_into(promoted_output_type(itr1, itr2), itr1, itr2)
+@inline unrolled_append(itr, itrs...) =
+    unrolled_reduce(unrolled_append, itrs, itr)
+
+@inline unrolled_prepend(itr, itrs...) = unrolled_append(itrs..., itr)
+
+@inline unrolled_take_into(output_type, itr, ::Val{N}) where {N} =
+    constructor_from_tuple(output_type)(
+        ntuple(Base.Fix1(generic_getindex, itr), Val(N)),
+    )
+@inline unrolled_take(itr, val_N) =
+    unrolled_take_into(inferred_output_type(itr), itr, val_N)
+
+@inline unrolled_drop_into(output_type, itr, ::Val{N}) where {N} =
+    constructor_from_tuple(output_type)(
+        ntuple(
+            Base.Fix1(generic_getindex, itr) ⋅ Base.Fix1(+, N),
+            Val(length(itr) - N),
+        ),
+    )
+@inline unrolled_drop(itr, val_N) =
+    unrolled_drop_into(inferred_output_type(itr), itr, val_N)
+
+##
+## Functions unrolled using either recursion or generated expressions
+##
+
 include("recursively_unrolled_functions.jl")
 include("generatively_unrolled_functions.jl")
 
-@inline unrolled_any(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_any : gen_unrolled_any)(f, itr)
-@inline unrolled_any(itr) = unrolled_any(identity, itr)
-
-@inline unrolled_all(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_all : gen_unrolled_all)(f, itr)
-@inline unrolled_all(itr) = unrolled_all(identity, itr)
-
-@inline unrolled_foreach(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_foreach : gen_unrolled_foreach)(f, itr)
-@inline unrolled_foreach(f, itrs...) = unrolled_foreach(splat(f), zip(itrs...))
-
+# The unrolled_map function could also be implemented in terms of ntuple, but
+# then it would be subject to the same recursion limit as ntuple. On Julia 1.10,
+# this leads to type instabilities in several unit tests for nested iterators.
 @inline unrolled_map_into_tuple(f::F, itr) where {F} =
     (rec_unroll(itr) ? rec_unrolled_map : gen_unrolled_map)(f, itr)
 @inline unrolled_map_into(output_type, f::F, itr) where {F} =
@@ -49,12 +152,17 @@ include("generatively_unrolled_functions.jl")
 @inline unrolled_map(f::F, itrs...) where {F} =
     unrolled_map(splat(f), zip(itrs...))
 
-@inline unrolled_applyat(f::F, n, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_applyat : gen_unrolled_applyat)(f, n, itr)
-@inline unrolled_applyat(f::F, n, itrs...) where {F} =
-    unrolled_applyat(splat(f), n, zip(itrs...))
-@inline unrolled_applyat_bounds_error() =
-    error("unrolled_applyat has detected an out-of-bounds index")
+@inline unrolled_any(itr) = unrolled_any(identity, itr)
+@inline unrolled_any(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_any : gen_unrolled_any)(f, itr)
+
+@inline unrolled_all(itr) = unrolled_all(identity, itr)
+@inline unrolled_all(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_all : gen_unrolled_all)(f, itr)
+
+@inline unrolled_foreach(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_foreach : gen_unrolled_foreach)(f, itr)
+@inline unrolled_foreach(f, itrs...) = unrolled_foreach(splat(f), zip(itrs...))
 
 @inline unrolled_reduce(op::O, itr, init) where {O} =
     isempty(itr) && init isa NoInit ?
@@ -66,75 +174,195 @@ include("generatively_unrolled_functions.jl")
 @inline unrolled_mapreduce(f::F, op::O, itrs...; init = NoInit()) where {F, O} =
     unrolled_reduce(op, unrolled_map(f, itrs...), init)
 
-@inline unrolled_accumulate_into_tuple(
-    op::O,
-    itr,
-    init,
-    transform::T,
-) where {O, T} =
+@inline unrolled_accumulate_into_tuple(op::O, itr, init) where {O} =
     (rec_unroll(itr) ? rec_unrolled_accumulate : gen_unrolled_accumulate)(
         op,
         itr,
         init,
-        transform,
     )
-@inline unrolled_accumulate_into(
-    output_type,
-    op::O,
-    itr,
-    init,
-    transform::T,
-) where {O, T} = constructor_from_tuple(output_type)(
-    unrolled_accumulate_into_tuple(op, itr, init, transform),
-)
-@inline unrolled_accumulate(op::O, itr, init, transform::T) where {O, T} =
+@inline unrolled_accumulate_into(output_type, op::O, itr, init) where {O} =
+    constructor_from_tuple(output_type)(
+        unrolled_accumulate_into_tuple(op, itr, init),
+    )
+@inline unrolled_accumulate(op::O, itr, init) where {O} =
     unrolled_accumulate_into(
-        accumulate_output_type(op, itr, init, transform),
+        unrolled_accumulate_output_type(op, itr, init),
         op,
         itr,
         init,
-        transform,
     )
-@inline unrolled_accumulate(
-    op::O,
-    itr;
-    init = NoInit(),
-    transform::T = identity,
-) where {O, T} = unrolled_accumulate(op, itr, init, transform)
+@inline unrolled_accumulate(op::O, itr; init = NoInit()) where {O} =
+    unrolled_accumulate(op, itr, init)
 
-@inline unrolled_push_into(output_type, itr, item) =
-    constructor_from_tuple(output_type)((itr..., item))
-@inline unrolled_push(itr, item) =
-    unrolled_push_into(inferred_output_type(itr), itr, item)
-
-@inline unrolled_append_into(output_type, itr1, itr2) =
-    constructor_from_tuple(output_type)((itr1..., itr2...))
-@inline unrolled_append(itr1, itr2) =
-    unrolled_append_into(promoted_output_type((itr1, itr2)), itr1, itr2)
-
-@inline unrolled_take_into(output_type, itr, ::Val{N}) where {N} =
-    constructor_from_tuple(output_type)(
-        ntuple(Base.Fix1(generic_getindex, itr), Val(N)),
+# The unrolled_ifelse function is for internal use, and it is not exported.
+# With one iterator as an argument, it is similar to
+# f(itr[1]) ? get_if(itr[1]) : f(itr[2]) ? get_if(itr[2]) ... : get_else().
+# With two iterators as arguments, it is similar to
+# f(itr1[1]) ? get_if(itr2[1]) : f(itr1[2]) ? get_if(itr2[2]) ... : get_else().
+# When f compares a constant isbits value computed from each item against a
+# non-constant isbits value (as in unrolled_applyat), unrolled_ifelse is
+# optimized into a switch instruction during LLVM code generation.
+@inline unrolled_ifelse(
+    f::F,
+    get_if::I,
+    get_else::E,
+    itr,
+    itrs...,
+) where {F, I, E} =
+    (rec_unroll(itr) ? rec_unrolled_ifelse : gen_unrolled_ifelse)(
+        f,
+        get_if,
+        get_else,
+        itr,
+        itrs...,
     )
-@inline unrolled_take(itr, val_N) =
-    unrolled_take_into(inferred_output_type(itr), itr, val_N)
 
-@inline unrolled_drop_into(output_type, itr, ::Val{N}) where {N} =
-    constructor_from_tuple(output_type)(
-        ntuple(n -> generic_getindex(itr, N + n), Val(length(itr) - N)),
-    )
-@inline unrolled_drop(itr, val_N) =
-    unrolled_drop_into(inferred_output_type(itr), itr, val_N)
+##
+## Unrolled functions without any analogues in Base
+##
 
-@inline unrolled_in(item, itr) = unrolled_any(Base.Fix1(===, item), itr)
+@inline unrolled_applyat(f::F, n, itr) where {F} = unrolled_ifelse(
+    ==(n),
+    f,
+    () -> throw(BoundsError(itr, n)),
+    static_range(itr),
+    itr,
+)
+@inline unrolled_applyat(f::F, n, itrs...) where {F} =
+    unrolled_applyat(splat(f), n, zip(itrs...))
+
+##
+## Unrolled analogues of functions from base/operators.jl and base/set.jl
+##
+
 # Using === instead of == or isequal improves type stability for singletons.
 
+@inline unrolled_in(item, itr) = unrolled_any(Base.Fix1(===, item), itr)
+
 @inline unrolled_unique(itr) =
-    unrolled_reduce(itr, inferred_empty(itr)) do unique_items, item
+    unrolled_reduce(itr, inferred_empty(itr)) do items, item
         @inline
-        unrolled_in(item, unique_items) ? unique_items :
-        unrolled_push(unique_items, item)
+        unrolled_in(item, items) ? items : unrolled_push(items, item)
     end
+@inline unrolled_unique(f::F, itr) where {F} =
+    unrolled_reduce(itr, ((), inferred_empty(itr))) do (f_values, items), item
+        @inline
+        f_value = f(item)
+        unrolled_in(f_value, f_values) ? (f_values, items) :
+        (unrolled_push(f_values, f_value), unrolled_push(items, item))
+    end[2]
+
+@inline unrolled_allunique(itr) = unrolled_allunique(identity, itr)
+@inline unrolled_allunique(f::F, itr) where {F} =
+    length(itr) == length(unrolled_unique(f, itr))
+
+@inline unrolled_allequal(itr) = unrolled_allequal(identity, itr)
+@inline unrolled_allequal(f::F, itr) where {F} =
+    isempty(itr) ? true :
+    unrolled_all(
+        Base.Fix1(===, f(generic_getindex(itr, 1))) ⋅ f,
+        unrolled_drop(itr, Val(1)),
+    )
+
+##
+## Unrolled analogues of functions from base/reduce.jl and base/accumulate.jl
+##
+
+# Sum and prod only need init when itr is empty, so it can be ignored otherwise.
+
+@inline unrolled_sum(itr; init = 0) = unrolled_sum(identity, itr; init)
+@inline unrolled_sum(f::F, itr; init = 0) where {F} =
+    isempty(itr) ? init : unrolled_mapreduce(f, +, itr)
+
+@inline unrolled_prod(itr; init = 1) = unrolled_prod(identity, itr; init)
+@inline unrolled_prod(f::F, itr; init = 1) where {F} =
+    isempty(itr) ? init : unrolled_mapreduce(f, *, itr)
+
+@inline unrolled_cumsum(itr) = unrolled_cumsum(identity, itr)
+@inline unrolled_cumsum(f::F, itr) where {F} =
+    unrolled_accumulate(+, unrolled_map(f, itr))
+
+@inline unrolled_cumprod(itr) = unrolled_cumprod(identity, itr)
+@inline unrolled_cumprod(f::F, itr) where {F} =
+    unrolled_accumulate(*, unrolled_map(f, itr))
+
+@inline unrolled_count(itr) = unrolled_count(identity, itr)
+@inline unrolled_count(f::F, itr) where {F} = unrolled_sum(Bool ⋅ f, itr)
+
+@inline unrolled_maximum(itr) = unrolled_maximum(identity, itr)
+@inline unrolled_maximum(f::F, itr) where {F} = unrolled_mapreduce(f, max, itr)
+
+@inline unrolled_minimum(itr) = unrolled_minimum(identity, itr)
+@inline unrolled_minimum(f::F, itr) where {F} = unrolled_mapreduce(f, min, itr)
+
+@inline extrema_reduction_operator((f_min1, f_max1), (f_min2, f_max2)) =
+    (min(f_min1, f_min2), max(f_max1, f_max2))
+@inline unrolled_extrema(itr) = unrolled_extrema(identity, itr)
+@inline unrolled_extrema(f::F, itr) where {F} =
+    unrolled_mapreduce(extrema_reduction_operator, itr) do item
+        @inline
+        f_value = f(item)
+        (f_value, f_value)
+    end
+
+@inline findmax_reduction_operator((f_value1, value1), (f_value2, value2)) =
+    f_value1 < f_value2 ? (f_value2, value2) : (f_value1, value1)
+@inline unrolled_findmax(itr) = unrolled_findmax(identity, itr)
+@inline unrolled_findmax(f::F, itr) where {F} =
+    unrolled_mapreduce(findmax_reduction_operator, enumerate(itr)) do (n, item)
+        @inline
+        (f(item), n)
+    end
+
+@inline findmin_reduction_operator((f_value1, value1), (f_value2, value2)) =
+    f_value1 > f_value2 ? (f_value2, value2) : (f_value1, value1)
+@inline unrolled_findmin(itr) = unrolled_findmin(identity, itr)
+@inline unrolled_findmin(f::F, itr) where {F} =
+    unrolled_mapreduce(findmin_reduction_operator, enumerate(itr)) do (n, item)
+        @inline
+        (f(item), n)
+    end
+
+@inline unrolled_argmax(itr) = unrolled_findmax(itr)[2]
+@inline unrolled_argmax(f::F, itr) where {F} =
+    unrolled_mapreduce(findmax_reduction_operator, itr) do item
+        @inline
+        (f(item), item)
+    end[2]
+
+@inline unrolled_argmin(itr) = unrolled_findmin(itr)[2]
+@inline unrolled_argmin(f::F, itr) where {F} =
+    unrolled_mapreduce(findmin_reduction_operator, itr) do item
+        @inline
+        (f(item), item)
+    end[2]
+
+##
+## Unrolled analogues of functions from base/arrays.jl
+##
+
+@inline unrolled_findfirst(itr) = unrolled_findfirst(identity, itr)
+@inline unrolled_findfirst(f::F, itr) where {F} =
+    unrolled_ifelse(f, identity, Returns(nothing), itr, static_range(itr))
+
+@inline unrolled_findlast(itr) = unrolled_findlast(identity, itr)
+@inline unrolled_findlast(f::F, itr) where {F} = unrolled_ifelse(
+    f,
+    identity,
+    Returns(nothing),
+    Iterators.reverse(itr),
+    Iterators.reverse(static_range(itr)),
+)
+
+@inline unrolled_argfirst(f::F, itr) where {F} = unrolled_ifelse(
+    f,
+    identity,
+    () -> error("itr does not contain any items for which f(item) is true"),
+    itr,
+)
+
+@inline unrolled_arglast(f::F, itr) where {F} =
+    unrolled_argfirst(f, Iterators.reverse(itr))
 
 @inline unrolled_filter(f::F, itr) where {F} =
     unrolled_reduce(itr, inferred_empty(itr)) do items_with_true_f, item
@@ -152,33 +380,53 @@ include("generatively_unrolled_functions.jl")
         (items_with_true_f, unrolled_push(items_with_false_f, item))
     end
 
+##
+## Unrolled analogues of functions from base/iterators.jl
+##
+
 @inline unrolled_flatten(itr) =
-    unrolled_reduce(unrolled_append, itr, promoted_empty(itr))
+    if isempty(itr)
+        inferred_empty(itr)
+    elseif length(itr) == 1
+        non_lazy_iterator(generic_getindex(itr, 1))
+    else
+        unrolled_reduce(unrolled_append, itr)
+    end
 
 @inline unrolled_flatmap(f::F, itrs...) where {F} =
     unrolled_flatten(unrolled_map(f, itrs...))
 
 @inline unrolled_product(itrs...) =
-    unrolled_reduce(itrs, (promoted_empty(itrs),)) do product_itr, itr
+    ntuple(Val(unrolled_prod(length, itrs))) do n
         @inline
-        unrolled_flatmap(itr) do item
+        items = ntuple(Val(length(itrs))) do itr_index
             @inline
-            unrolled_map_into_tuple(Base.Fix2(unrolled_push, item), product_itr)
+            cur_length = length(itrs[itr_index])
+            prev_length = unrolled_prod(length, itrs[1:(itr_index - 1)])
+            item_index = (n - 1) ÷ prev_length % cur_length + 1
+            generic_getindex(itrs[itr_index], item_index)
         end
+        # Since the iterators are passed as individual arguments, the number of
+        # items is limited by the number of argument registers, so we can just
+        # use constructor_from_tuple and avoid sacrificing compilation time to
+        # optimize for low-storage iterators (e.g., by using unrolled_push).
+        constructor_from_tuple(promoted_output_type(itrs...))(items)
     end
 
-abstract type StaticSequence{N} end
+@inline unrolled_cycle(itr, ::Val{N}) where {N} =
+    unrolled_flatten(ntuple(Returns(itr), Val(N)))
 
-@inline Base.length(::StaticSequence{N}) where {N} = N
-@inline Base.firstindex(::StaticSequence) = 1
-@inline Base.lastindex(itr::StaticSequence) = length(itr)
-@inline Base.getindex(itr::StaticSequence, n::Integer) =
-    generic_getindex(itr, n)
-@inline Base.iterate(itr::StaticSequence, n = 1) =
-    n > length(itr) ? nothing : (generic_getindex(itr, n), n + 1)
+@inline unrolled_partition(itr, ::Val{N}) where {N} =
+    ntuple(Val(cld(length(itr), N))) do partition_number
+        @inline
+        first_index = N * (partition_number - 1)
+        last_index = min(length(itr), N * partition_number)
+        unrolled_drop(unrolled_take(itr, Val(last_index)), Val(first_index))
+    end
 
-include("StaticOneTo.jl")
-include("StaticBitVector.jl")
+##
+## Additional instructions for compilation
+##
 
 # Remove the default recursion limit from every function defined in this module.
 @static if hasfield(Method, :recursion_relation)

--- a/src/generatively_unrolled_functions.jl
+++ b/src/generatively_unrolled_functions.jl
@@ -1,3 +1,9 @@
+@generated _gen_unrolled_map(::Val{N}, f, itr) where {N} = quote
+    @inline
+    return Base.Cartesian.@ntuple $N n -> f(generic_getindex(itr, n))
+end
+@inline gen_unrolled_map(f, itr) = _gen_unrolled_map(Val(length(itr)), f, itr)
+
 @generated _gen_unrolled_any(::Val{N}, f, itr) where {N} = quote
     @inline
     return Base.Cartesian.@nany $N n -> f(generic_getindex(itr, n))
@@ -18,52 +24,55 @@ end
 @inline gen_unrolled_foreach(f, itr) =
     _gen_unrolled_foreach(Val(length(itr)), f, itr)
 
-@generated _gen_unrolled_map(::Val{N}, f, itr) where {N} = quote
-    @inline
-    return Base.Cartesian.@ntuple $N n -> f(generic_getindex(itr, n))
-end
-@inline gen_unrolled_map(f, itr) = _gen_unrolled_map(Val(length(itr)), f, itr)
-
-@generated _gen_unrolled_applyat(::Val{N}, f, n′, itr) where {N} = quote
-    @inline
-    Base.Cartesian.@nexprs $N n ->
-        (n′ == n && return f(generic_getindex(itr, n)))
-    unrolled_applyat_bounds_error()
-end # This is optimized into a switch instruction during LLVM code generation.
-@inline gen_unrolled_applyat(f, n, itr) =
-    _gen_unrolled_applyat(Val(length(itr)), f, n, itr)
-
 @generated _gen_unrolled_reduce(::Val{N}, op, itr, init) where {N} = quote
     @inline
-    value_0 = init
-    $N == 0 && return value_0
-    return Base.Cartesian.@nexprs $N n ->
-        (value_n = op(value_{n - 1}, generic_getindex(itr, n)))
-end
-@generated _gen_unrolled_reduce(::Val{N}, op, itr, ::NoInit) where {N} = quote
-    @inline
-    value_1 = generic_getindex(itr, 1)
-    $N == 1 && return value_1
-    return Base.Cartesian.@nexprs $(N - 1) n ->
+    $N == 0 && return init
+    first_itr_item = generic_getindex(itr, 1)
+    value_1 = init isa NoInit ? first_itr_item : op(init, first_itr_item)
+    Base.Cartesian.@nexprs $(N - 1) n ->
         (value_{n + 1} = op(value_n, generic_getindex(itr, n + 1)))
+    return $(Symbol(:value_, N))
 end
 @inline gen_unrolled_reduce(op, itr, init) =
     _gen_unrolled_reduce(Val(length(itr)), op, itr, init)
 
-@generated _gen_unrolled_accumulate(
-    ::Val{N},
-    op,
-    itr,
-    init,
-    transform,
-) where {N} = quote
+@generated _gen_unrolled_accumulate(::Val{N}, op, itr, init) where {N} = quote
     @inline
     $N == 0 && return ()
     first_itr_item = generic_getindex(itr, 1)
     value_1 = init isa NoInit ? first_itr_item : op(init, first_itr_item)
     Base.Cartesian.@nexprs $(N - 1) n ->
         (value_{n + 1} = op(value_n, generic_getindex(itr, n + 1)))
-    return Base.Cartesian.@ntuple $N n -> transform(value_n)
+    return Base.Cartesian.@ntuple $N n -> value_n
 end
-@inline gen_unrolled_accumulate(op, itr, init, transform) =
-    _gen_unrolled_accumulate(Val(length(itr)), op, itr, init, transform)
+@inline gen_unrolled_accumulate(op, itr, init) =
+    _gen_unrolled_accumulate(Val(length(itr)), op, itr, init)
+
+@generated _gen_unrolled_ifelse(::Val{N}, f, get_if, get_else, itr) where {N} =
+    quote
+        @inline
+        Base.Cartesian.@nexprs $N n -> begin
+            item = generic_getindex(itr, n)
+            f(item) && return get_if(item)
+        end
+        return get_else()
+    end
+@inline gen_unrolled_ifelse(f, get_if, get_else, itr) =
+    _gen_unrolled_ifelse(Val(length(itr)), f, get_if, get_else, itr)
+
+@generated _gen_unrolled_ifelse2(
+    ::Val{N},
+    f,
+    get_if,
+    get_else,
+    itr1,
+    itr2,
+) where {N} = quote
+    @inline
+    Base.Cartesian.@nexprs $N n -> begin
+        f(generic_getindex(itr1, n)) && return get_if(generic_getindex(itr2, n))
+    end
+    return get_else()
+end
+@inline gen_unrolled_ifelse(f, get_if, get_else, itr1, itr2) =
+    _gen_unrolled_ifelse2(Val(length(itr1)), f, get_if, get_else, itr1, itr2)

--- a/src/unrollable_iterator_interface.jl
+++ b/src/unrollable_iterator_interface.jl
@@ -3,24 +3,28 @@
 
 Whether to use recursive loop unrolling instead of generative loop unrolling for
 the iterator `itr`. Recursive unrolling can lead to suboptimal LLVM code for
-iterators of more than 32 items, so this is set to `false` by default.
+iterators of more than 32 items, but it is typically faster than generative
+unrolling for short iterators. By default, recursive unrolling is used for
+iterators up to length 2, and generative unrolling is used for longer iterators.
 """
-@inline rec_unroll(itr) = false
+@inline rec_unroll(itr) = length(itr) <= 2
 
 """
     generic_getindex(itr, n)
 
 Identical to `getindex(itr, n)`, but with the added ability to handle lazy
 iterator types defined in the standard library, such as `Base.Generator` and
-`Base.Iterators.Enumerate`.
+`Iterators.Enumerate`.
 """
 @inline generic_getindex(itr, n) = getindex(itr, n)
 @inline generic_getindex(itr::Base.Generator, n) =
     itr.f(generic_getindex(itr.iter, n))
-@inline generic_getindex(itr::Base.Iterators.Enumerate, n) =
+@inline generic_getindex(itr::Iterators.Reverse, n) =
+    generic_getindex(itr.itr, length(itr.itr) - n + 1)
+@inline generic_getindex(itr::Iterators.Enumerate, n) =
     (n, generic_getindex(itr.itr, n))
-@inline generic_getindex(itr::Base.Iterators.Zip, n) =
-    unrolled_map_into_tuple(Base.Fix2(generic_getindex, n), itr.is)
+@inline generic_getindex(itr::Iterators.Zip, n) =
+    unrolled_map(Base.Fix2(generic_getindex, n), itr.is)
 
 @inline first_item_type(itr) =
     Base.promote_op(Base.Fix2(generic_getindex, 1), typeof(itr))
@@ -40,10 +44,12 @@ lazy iterator without any associated output type. Defaults to `Tuple`.
     NamedTuple{names}
 @inline output_type_for_promotion(itr::Base.Generator) =
     output_type_for_promotion(itr.iter)
-@inline output_type_for_promotion(itr::Base.Iterators.Enumerate) =
+@inline output_type_for_promotion(itr::Iterators.Reverse) =
     output_type_for_promotion(itr.itr)
-@inline output_type_for_promotion(itr::Base.Iterators.Zip) =
-    maybe_ambiguous_promoted_output_type(itr.is)
+@inline output_type_for_promotion(itr::Iterators.Enumerate) =
+    output_type_for_promotion(itr.itr)
+@inline output_type_for_promotion(itr::Iterators.Zip) =
+    maybe_ambiguous_promoted_output_type(itr.is...)
 
 """
     AmbiguousOutputType
@@ -125,7 +131,7 @@ default result for all other pairs of unequal output types is `Union{}`.
            $O12 for $O1 followed by $O2, versus $O21 for $O2 followed by $O1")
 end
 
-@inline maybe_ambiguous_promoted_output_type(itrs) =
+@inline maybe_ambiguous_promoted_output_type(itrs...) =
     isempty(itrs) ? Tuple : # Generate a Tuple when given 0 inputs.
     unrolled_mapreduce(output_type_for_promotion, output_promote_result, itrs)
 
@@ -134,35 +140,23 @@ end
         @inline
         first_item_type(itr)
     end
-@inline inferred_output_type(itr::Base.Generator) =
-    unambiguous_output_type(output_type_for_promotion(itr.iter)) do
-        @inline
-        Base.promote_op(itr.f, first_item_type(itr.iter))
-    end
-@inline inferred_output_type(itr::Base.Iterators.Enumerate) =
-    unambiguous_output_type(output_type_for_promotion(itr.itr)) do
-        @inline
-        Tuple{Int, first_item_type(itr.itr)}
-    end
-@inline inferred_output_type(itr::Base.Iterators.Zip) =
-    unambiguous_output_type(maybe_ambiguous_promoted_output_type(itr.is)) do
-        @inline
-        Tuple{unrolled_map_into_tuple(first_item_type, itr.is)...}
-    end
 
-@inline promoted_output_type(itrs) =
-    unambiguous_output_type(maybe_ambiguous_promoted_output_type(itrs)) do
+@inline promoted_output_type(itrs...) =
+    unambiguous_output_type(maybe_ambiguous_promoted_output_type(itrs...)) do
         @inline
         first_item_type(generic_getindex(itrs, 1))
     end
 
-@inline accumulate_output_type(op, itr, init, transform) =
+@inline unrolled_map_output_type(f, itr) =
+    inferred_output_type(Iterators.map(f, itr))
+
+@inline unrolled_accumulate_output_type(op, itr, init) =
     unambiguous_output_type(output_type_for_promotion(itr)) do
         @inline
         no_init = init isa NoInit
         arg1_type = no_init ? first_item_type(itr) : typeof(init)
         arg2_type = no_init ? second_item_type(itr) : first_item_type(itr)
-        Base.promote_op(transform, Base.promote_op(op, arg1_type, arg2_type))
+        Base.promote_op(op, arg1_type, arg2_type)
     end
 
 """
@@ -195,4 +189,5 @@ An empty output of type `output_type`. Defaults to applying the
 
 @inline inferred_empty(itr) = empty_output(inferred_output_type(itr))
 
-@inline promoted_empty(itrs) = empty_output(promoted_output_type(itrs))
+# This makes lazy iterators non-lazy, and it is a no-op for non-lazy iterators.
+@inline non_lazy_iterator(itr) = unrolled_append(itr, inferred_empty(itr))

--- a/test/test_and_analyze.jl
+++ b/test/test_and_analyze.jl
@@ -23,7 +23,7 @@ function print_comparison_table(title, comparison_table_dict, io = stdout)
         if contains(optimization, "better") ||
            contains(optimization, "fewer allocs") &&
            !contains(run_time, "more") ||
-           contains(optimization, "identical") && contains(run_time, "less")
+           contains(optimization, "similar") && contains(run_time, "less")
             # better performance
             if !contains(run_time, "more") &&
                !contains(compile_time, "more") &&
@@ -46,7 +46,7 @@ function print_comparison_table(title, comparison_table_dict, io = stdout)
                     color(writing_to_docs ? "khaki" : "yellow")
                 end
             end
-        elseif contains(optimization, "identical") &&
+        elseif contains(optimization, "similar") &&
                contains(run_time, "similar")
             # similar performance
             if contains(compile_time, "less") && !contains(allocs, "more") ||
@@ -155,17 +155,26 @@ function memory_string(bytes)
     end
 end
 
-function comparison_string(value1, value2, to_string, to_number = identity)
-    ratio = to_number(value1) / to_number(value2)
-    ratio_str = if ratio >= 2
-        floored_ratio = ratio == Inf ? Inf : floor(Int, ratio)
-        "$floored_ratio times more"
-    elseif inv(ratio) >= 2
-        floored_inv_ratio = ratio == 0 ? Inf : floor(Int, inv(ratio))
-        "$floored_inv_ratio times less"
-    else
-        "similar"
-    end
+function comparison_string(
+    value1,
+    value2,
+    to_string;
+    to_number = identity,
+    epsilon = 0,
+)
+    number1 = to_number(value1)
+    number2 = to_number(value2)
+    ratio = number1 / number2
+    ratio_str =
+        if ratio < 2 && inv(ratio) < 2 || number1 < epsilon && number2 < epsilon
+            "similar"
+        elseif ratio >= 2
+            floored_ratio = ratio == Inf ? Inf : floor(Int, ratio)
+            "$floored_ratio times more"
+        else
+            floored_inv_ratio = ratio == 0 ? Inf : floor(Int, inv(ratio))
+            "$floored_inv_ratio times less"
+        end
     return "$ratio_str ($(to_string(value1)) vs. $(to_string(value2)))"
 end
 
@@ -285,28 +294,38 @@ macro test_unrolled(
             isdefined(code_instance(unrolled_func, $(args...)), :rettype_const)
         is_reference_const =
             isdefined(code_instance(reference_func, $(args...)), :rettype_const)
-        # Base.issingletontype(typeof(($(args...),))) && @test is_unrolled_const
 
         buffer = IOBuffer()
-
-        # Determine whether the functions are fully optimized out.
         args_type = Tuple{map(typeof, ($(args...),))...}
         code_llvm(buffer, unrolled_func, args_type; debuginfo = :none)
-        is_unrolled_optimized_out =
-            length(split(String(take!(buffer)), '\n')) == 5
+        unrolled_llvm = String(take!(buffer))
         code_llvm(buffer, reference_func, args_type; debuginfo = :none)
-        is_reference_optimized_out =
-            length(split(String(take!(buffer)), '\n')) == 5
+        reference_llvm = String(take!(buffer))
+        code_llvm(buffer, Returns(nothing), Tuple{}; debuginfo = :none)
+        no_op_llvm = String(take!(buffer))
+
+        # Test whether the functions are compiled into switch instructions.
+        is_unrolled_switch = contains(unrolled_llvm, "switch")
+        is_reference_switch = contains(reference_llvm, "switch")
+
+        # Test whether the functions are fully optimized out.
+        unrolled_llvm_lines = length(split(unrolled_llvm, '\n'))
+        reference_llvm_lines = length(split(reference_llvm, '\n'))
+        no_op_llvm_lines = length(split(no_op_llvm, '\n'))
+        is_unrolled_no_op = unrolled_llvm_lines == no_op_llvm_lines
+        is_reference_no_op = reference_llvm_lines == no_op_llvm_lines
 
         # Test the overall level of optimization.
         unrolled_opt_str, unrolled_opt_score = if unrolled_run_memory > 0
             "$(memory_string(unrolled_run_memory)) allocs", 1 / unrolled_run_memory
         elseif !is_unrolled_stable
             "type-unstable", 2
-        elseif !is_unrolled_const && !is_unrolled_optimized_out
-            "type-stable", 3
-        elseif !is_unrolled_optimized_out
-            "constant", 4
+        elseif !is_unrolled_const && !is_unrolled_switch
+            "$unrolled_llvm_lines LLVM lines", 3
+        elseif !is_unrolled_const
+            "$unrolled_llvm_lines LLVM lines w/ switch", 3 # same as no switch
+        elseif !is_unrolled_no_op
+            "$unrolled_llvm_lines LLVM lines w/ Const", 4
         else
             "optimized out", 5
         end
@@ -315,10 +334,12 @@ macro test_unrolled(
             1 / reference_run_memory
         elseif !is_reference_stable
             "type-unstable", 2
-        elseif !is_reference_const && !is_reference_optimized_out
-            "type-stable", 3
-        elseif !is_reference_optimized_out
-            "constant", 4
+        elseif !is_reference_const && !is_reference_switch
+            "$reference_llvm_lines LLVM lines", 3
+        elseif !is_reference_const
+            "$reference_llvm_lines LLVM lines w/ switch", 3 # same as no switch
+        elseif !is_reference_no_op
+            "$reference_llvm_lines LLVM lines w/ Const", 4
         else
             "optimized out", 5
         end
@@ -377,12 +398,13 @@ macro test_unrolled(
         elseif unrolled_opt_score < reference_opt_score
             "worse ($unrolled_opt_str vs. $reference_opt_str)"
         else
-            "identical ($unrolled_opt_str)"
+            "similar ($unrolled_opt_str)"
         end
         run_time_str = comparison_string(
             unrolled_run_time,
             reference_run_time,
-            time_string,
+            time_string;
+            epsilon = 50, # Ignore differences between times shorter than 50 ns.
         )
         compile_time_str = comparison_string(
             unrolled_compile_time,
@@ -394,8 +416,8 @@ macro test_unrolled(
             (reference_total_memory, reference_total_rss),
             ((gc_bytes, rss_bytes),) ->
                 rss_bytes == 0 ? memory_string(gc_bytes) :
-                "$(memory_string(gc_bytes)) [$(memory_string(rss_bytes))]",
-            first, # Use GC value for comparison since RSS might be unavailable.
+                "$(memory_string(gc_bytes)) [$(memory_string(rss_bytes))]";
+            to_number = first, # Use GC number since RSS might be unavailable.
         )
 
         dict_key = ($unrolled_expr_str, $reference_expr_str)
@@ -439,6 +461,8 @@ function tuples_of_tuples_contents_str(itrs...)
     return str
 end
 
+itr_lengths = "fast_mode" in ARGS ? (8,) : (2, 4, 8, 32, 128)
+
 # NOTE: In the tests below, random numbers are meant to emulate values that
 # cannot be inferred during compilation.
 
@@ -449,16 +473,45 @@ for itr in (
     tuple_of_tuples(1, 0, true, true),
     tuple_of_tuples(1, 1, true, true),
     tuple_of_tuples(1, 1, false, true),
-    map(n -> tuple_of_tuples(n, 0, true, true), (8, 32, 33, 128))...,
-    map(n -> tuple_of_tuples(n, 1, true, true), (8, 32, 33, 128))...,
-    map(n -> tuple_of_tuples(n, 1, false, true), (8, 32, 33, 128))...,
-    map(n -> tuple_of_tuples(n, 0, true, false), (8, 32, 33, 128))...,
-    map(n -> tuple_of_tuples(n, 1, true, false), (8, 32, 33, 128))...,
-    map(n -> tuple_of_tuples(n, 1, false, false), (8, 32, 33, 128))...,
+    map(n -> tuple_of_tuples(n, 1, true, true), itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, false, true), itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 0, true, false), itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, true, false), itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, false, false), itr_lengths)...,
 )
     str = tuples_of_tuples_contents_str(itr)
     itr_description = "a Tuple that contains $(length(itr)) $str"
     @testset "individual unrolled functions of $itr_description" begin
+        @test_unrolled (itr,) unrolled_push(itr, itr[1]) (itr..., itr[1]) str
+
+        @test_unrolled(
+            (itr,),
+            unrolled_append(itr, Iterators.reverse(itr)),
+            (itr..., Iterators.reverse(itr)...),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_prepend(itr, Iterators.reverse(itr)),
+            (Iterators.reverse(itr)..., itr...),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_take(itr, Val(length(itr) ÷ 2)),
+            itr[1:(length(itr) ÷ 2)],
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_drop(itr, Val(length(itr) ÷ 2)),
+            itr[(length(itr) ÷ 2 + 1):end],
+            str,
+        )
+
+        @test_unrolled (itr,) unrolled_map(length, itr) map(length, itr) str
+
         @test_unrolled (itr,) unrolled_any(isempty, itr) any(isempty, itr) str
         @test_unrolled(
             (itr,),
@@ -482,15 +535,6 @@ for itr in (
             str,
         )
 
-        @test_unrolled (itr,) unrolled_map(length, itr) map(length, itr) str
-
-        @test_unrolled(
-            (itr,),
-            unrolled_applyat(length, rand(1:7:length(itr)), itr),
-            length(itr[rand(1:7:length(itr))]),
-            str,
-        )
-
         @test_unrolled (itr,) unrolled_reduce(tuple, itr) reduce(tuple, itr) str
         @test_unrolled(
             (itr,),
@@ -501,18 +545,18 @@ for itr in (
 
         @test_unrolled(
             (itr,),
-            unrolled_mapreduce(length, +, itr),
-            mapreduce(length, +, itr),
+            unrolled_mapreduce(x -> (x, length(x)), tuple, itr),
+            mapreduce(x -> (x, length(x)), tuple, itr),
             str,
         )
         @test_unrolled(
             (itr,),
-            unrolled_mapreduce(length, +, itr; init = 0),
-            mapreduce(length, +, itr; init = 0),
+            unrolled_mapreduce(x -> (x, length(x)), tuple, itr; init = ()),
+            mapreduce(x -> (x, length(x)), tuple, itr; init = ()),
             str,
         )
 
-        if length(itr) <= 33
+        if length(itr) <= 32
             @test_unrolled(
                 (itr,),
                 unrolled_accumulate(tuple, itr),
@@ -527,19 +571,10 @@ for itr in (
             )
         end # These can take half a minute to compile when the length is 128.
 
-        @test_unrolled (itr,) unrolled_push(itr, itr[1]) (itr..., itr[1]) str
-        @test_unrolled (itr,) unrolled_append(itr, itr) (itr..., itr...) str
-
         @test_unrolled(
             (itr,),
-            unrolled_take(itr, Val(length(itr) ÷ 2)),
-            itr[1:(length(itr) ÷ 2)],
-            str,
-        )
-        @test_unrolled(
-            (itr,),
-            unrolled_drop(itr, Val(length(itr) ÷ 2)),
-            itr[(length(itr) ÷ 2 + 1):end],
+            unrolled_applyat(length, rand(1:7:length(itr)), itr),
+            length(itr[rand(1:7:length(itr))]),
             str,
         )
 
@@ -549,12 +584,154 @@ for itr in (
 
         @test_unrolled(
             (itr,),
+            unrolled_unique(length, itr),
+            Tuple(unique(length, itr)),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
             unrolled_unique(itr),
             Tuple(unique(itr)),
             str,
             !Base.issingletontype(typeof(itr)),
             !Base.issingletontype(typeof(itr)),
-        ) # unrolled_unique is type-unstable for non-singleton values
+        ) # unrolled_unique is only type-stable when comparing Core.Const data
+
+        if VERSION >= v"1.11"
+            @test_unrolled(
+                (itr,),
+                unrolled_allunique(length, itr),
+                allunique(length, itr),
+                str,
+            )
+            @test_unrolled(
+                (itr,),
+                unrolled_allequal(length, itr),
+                allequal(length, itr),
+                str,
+            )
+        else
+            @test_unrolled(
+                (itr,),
+                unrolled_allunique(length, itr),
+                allunique(Iterators.map(length, itr)),
+                str,
+            )
+            @test_unrolled(
+                (itr,),
+                unrolled_allequal(length, itr),
+                allequal(Iterators.map(length, itr)),
+                str,
+            )
+        end # allunique(f, itr) and allequal(f, itr) require at least Julia 1.11
+
+        @test_unrolled (itr,) unrolled_sum(length, itr) sum(length, itr) str
+        @test_unrolled (itr,) unrolled_prod(length, itr) prod(length, itr) str
+
+        @test_unrolled(
+            (itr,),
+            unrolled_cumsum(length, itr),
+            Tuple(cumsum(Iterators.map(length, itr))),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_cumprod(length, itr),
+            Tuple(cumprod(Iterators.map(length, itr))),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_count(!isempty, itr),
+            count(!isempty, itr),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_maximum(length, itr),
+            maximum(length, itr),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_minimum(length, itr),
+            minimum(length, itr),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_extrema(length, itr),
+            extrema(length, itr),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_findmax(length, itr),
+            findmax(length, itr),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_findmin(length, itr),
+            findmin(length, itr),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_argmax(length, itr),
+            argmax(length, itr),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_argmin(length, itr),
+            argmin(length, itr),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_argmax(unrolled_map(length, itr)),
+            argmax(Iterators.map(length, itr)),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_argmin(unrolled_map(length, itr)),
+            argmin(Iterators.map(length, itr)),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_findfirst(!isempty, itr),
+            findfirst(!isempty, itr),
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_findlast(isempty, itr),
+            findlast(isempty, itr),
+            str,
+        )
+
+        @test_unrolled(
+            (itr,),
+            unrolled_argfirst(x -> length(x) >= length(itr[end]), itr),
+            itr[findfirst(x -> length(x) >= length(itr[end]), itr)],
+            str,
+        )
+        @test_unrolled(
+            (itr,),
+            unrolled_arglast(x -> length(x) >= length(itr[1]), itr),
+            itr[findlast(x -> length(x) >= length(itr[1]), itr)],
+            str,
+        )
 
         @test_unrolled(
             (itr,),
@@ -579,19 +756,19 @@ for itr in (
 
         @test_unrolled(
             (itr,),
-            unrolled_flatmap(reverse, itr),
-            Tuple(Iterators.flatmap(reverse, itr)),
+            unrolled_flatmap(Iterators.reverse, itr),
+            Tuple(Iterators.flatmap(Iterators.reverse, itr)),
             str,
         )
 
-        if length(itr) <= 33
+        if length(itr) <= 32
             @test_unrolled(
                 (itr,),
                 unrolled_product(itr, itr),
                 Tuple(Iterators.product(itr, itr)),
                 str,
             )
-        end
+        end # This can take several minutes to compile when the length is 128.
         if length(itr) <= 8
             @test_unrolled(
                 (itr,),
@@ -600,6 +777,22 @@ for itr in (
                 str,
             )
         end # This can take several minutes to compile when the length is 32.
+
+        if VERSION >= v"1.11"
+            @test_unrolled(
+                (itr,),
+                unrolled_cycle(itr, Val(3)),
+                Tuple(Iterators.cycle(itr, 3)),
+                str,
+            )
+        end # Iterators.cycle(itr, n) requires at least Julia 1.11
+
+        @test_unrolled(
+            (itr,),
+            unrolled_partition(itr, Val(3)),
+            Tuple(Iterators.map(Tuple, Iterators.partition(itr, 3))),
+            str,
+        )
     end
 end
 
@@ -613,14 +806,14 @@ for (itr1, itr2, itr3) in (
         tuple_of_tuples(1, 1, false, true),
     ),
     zip(
-        map(n -> tuple_of_tuples(n, 0, true, true), (8, 32, 33, 128)),
-        map(n -> tuple_of_tuples(n, 1, true, true), (8, 32, 33, 128)),
-        map(n -> tuple_of_tuples(n, 1, false, true), (8, 32, 33, 128)),
+        map(n -> tuple_of_tuples(n, 0, true, true), itr_lengths),
+        map(n -> tuple_of_tuples(n, 1, true, true), itr_lengths),
+        map(n -> tuple_of_tuples(n, 1, false, true), itr_lengths),
     )...,
     zip(
-        map(n -> tuple_of_tuples(n, 0, true, false), (8, 32, 33, 128)),
-        map(n -> tuple_of_tuples(n, 1, true, false), (8, 32, 33, 128)),
-        map(n -> tuple_of_tuples(n, 1, false, false), (8, 32, 33, 128)),
+        map(n -> tuple_of_tuples(n, 0, true, false), itr_lengths),
+        map(n -> tuple_of_tuples(n, 1, true, false), itr_lengths),
+        map(n -> tuple_of_tuples(n, 1, false, false), itr_lengths),
     )...,
 )
     str3 = tuples_of_tuples_contents_str(itr3)
@@ -631,15 +824,22 @@ for (itr1, itr2, itr3) in (
     @testset "nested unrolled functions of $itr_description" begin
         @test_unrolled(
             (itr3,),
-            unrolled_any(x -> unrolled_reduce(+, x) > 7, itr3),
-            any(x -> reduce(+, x) > 7, itr3),
+            unrolled_any(x -> unrolled_sum(x) > 7, itr3),
+            any(x -> sum(x) > 7, itr3),
             str3,
         )
 
         @test_unrolled(
             (itr3,),
-            unrolled_mapreduce(x -> unrolled_reduce(+, x), max, itr3),
-            mapreduce(x -> reduce(+, x), max, itr3),
+            unrolled_mapreduce(unrolled_sum, max, itr3),
+            mapreduce(sum, max, itr3),
+            str3,
+        )
+
+        @test_unrolled(
+            (itr3,),
+            unrolled_applyat(unrolled_minimum, rand(1:length(itr3)), itr3),
+            minimum(itr3[rand(1:length(itr3))]),
             str3,
         )
 
@@ -695,34 +895,31 @@ end
 
 nested_iterator(depth, n, inner_n) =
     depth == 1 ? ntuple(identity, n) :
-    ntuple(
-        Returns(nested_iterator(depth - 1, Int(n / inner_n), inner_n)),
-        inner_n,
-    )
+    ntuple(Returns(nested_iterator(depth - 1, n ÷ inner_n, inner_n)), inner_n)
 
 title = "Recursive Unrolled Functions"
 comparison_table_dict = (comparison_table_dicts[title] = OrderedDict())
 
-for n in (8, 32, 128)
-    itr_description = "a Tuple that contains $n values in nested Tuples"
-    @testset "recursive unrolled functions of $itr_description" begin
-        for depth in (2, 3, 4:2:(Int(log2(n)) + 1)...)
+for n in itr_lengths
+    @testset "recursive unrolled functions of $n values in nested Tuples" begin
+        for depth in 2:2:(Int(log2(n)) + 1)
             itr = nested_iterator(depth, n, 2)
-            str = "$itr_description of depth $depth"
+            str =
+                depth > 2 ?
+                "nested Tuples with $(n ÷ 2) values at depth $(depth - 1)" :
+                (n > 2 ? "Tuples with $(n ÷ 2) values" : "Tuples with 1 value")
             # In the following definitions, use var"#self#" to avoid boxing:
             # discourse.julialang.org/t/performant-recursive-anonymous-functions/90984/5
             @test_unrolled(
                 (itr,),
                 map(
                     x ->
-                        eltype(x) <: Tuple ?
-                        unrolled_mapreduce(var"#self#", +, x) : length(x),
+                        eltype(x) <: Tuple ? unrolled_sum(var"#self#", x) :
+                        length(x),
                     (itr,),
                 )[1],
                 map(
-                    x ->
-                        eltype(x) <: Tuple ? mapreduce(var"#self#", +, x) :
-                        length(x),
+                    x -> eltype(x) <: Tuple ? sum(var"#self#", x) : length(x),
                     (itr,),
                 )[1],
                 str,
@@ -731,19 +928,34 @@ for n in (8, 32, 128)
                 (itr,),
                 map(
                     x ->
-                        eltype(x) <: Tuple ?
-                        unrolled_mapreduce(var"#self#", +, x) :
-                        unrolled_reduce(+, x),
+                        eltype(x) <: Tuple ? unrolled_sum(var"#self#", x) :
+                        unrolled_sum(x),
                     (itr,),
                 )[1],
                 map(
-                    x ->
-                        eltype(x) <: Tuple ? mapreduce(var"#self#", +, x) :
-                        reduce(+, x),
+                    x -> eltype(x) <: Tuple ? sum(var"#self#", x) : sum(x),
                     (itr,),
                 )[1],
                 str,
             ) # nested iterator sum
+            @test_unrolled(
+                (itr,),
+                map(
+                    x ->
+                        eltype(x) <: Tuple ?
+                        unrolled_sum(var"#self#", x) +
+                        unrolled_sum(log ∘ var"#self#", x) : unrolled_sum(x),
+                    (itr,),
+                )[1],
+                map(
+                    x ->
+                        eltype(x) <: Tuple ?
+                        sum(var"#self#", x) + sum(log ∘ var"#self#", x) :
+                        sum(x),
+                    (itr,),
+                )[1],
+                str,
+            ) # recursive function that is improved by unrolling on Julia 1.11
         end
     end
 end
@@ -848,10 +1060,10 @@ comparison_table_dict = (comparison_table_dicts[title] = OrderedDict())
 @testset "unrolled functions of an empty Tuple" begin
     itr = ()
     str = "nothing"
+    @test_unrolled (itr,) unrolled_map(error, itr) map(error, itr) str
     @test_unrolled (itr,) unrolled_any(error, itr) any(error, itr) str
     @test_unrolled (itr,) unrolled_all(error, itr) all(error, itr) str
     @test_unrolled (itr,) unrolled_foreach(error, itr) foreach(error, itr) str
-    @test_unrolled (itr,) unrolled_map(error, itr) map(error, itr) str
     @test_throws "init" unrolled_reduce(error, itr)
     @test_unrolled(
         (itr,),
@@ -878,33 +1090,44 @@ comparison_table_dict = (comparison_table_dicts[title] = OrderedDict())
 
 @testset "unrolled functions of Tuples vs. StaticOneTos" begin
     for itr in (ntuple(identity, 2000), StaticOneTo(2000), StaticOneTo(9000))
-        @test_unrolled (itr,) unrolled_reduce(+, itr) reduce(+, itr) "Ints"
-        @test_unrolled(
-            (itr,),
-            unrolled_mapreduce(log, +, itr),
-            mapreduce(log, +, itr),
-            "Ints",
-        )
+        @test_unrolled (itr,) unrolled_sum(itr) sum(itr) "Ints"
+        @test_unrolled((itr,), unrolled_sum(log, itr), sum(log, itr), "Ints",)
     end # These can take over a minute to compile for ntuple(identity, 9000).
 end
 
 title = "Generative vs. Recursive Unrolling"
 comparison_table_dict = (comparison_table_dicts[title] = OrderedDict())
 
+gen_vs_rec_itr_lengths = if "fast_mode" in ARGS
+    (8,)
+elseif VERSION >= v"1.11" && (Sys.iswindows() || Sys.isapple())
+    # JET sometimes throws stack overflow errors for 256 elements on Julia 1.11.
+    (1:8..., 16, 32, 128)
+else
+    (1:8..., 16, 32, 128, 256)
+end
+
 for itr in (
     tuple_of_tuples(1, 0, true, true),
     tuple_of_tuples(1, 1, true, true),
     tuple_of_tuples(1, 1, false, true),
-    map(n -> tuple_of_tuples(n, 0, true, true), (8, 16, 32, 33, 128, 256))...,
-    map(n -> tuple_of_tuples(n, 1, true, true), (8, 16, 32, 33, 128, 256))...,
-    map(n -> tuple_of_tuples(n, 1, false, true), (8, 16, 32, 33, 128, 256))...,
-    map(n -> tuple_of_tuples(n, 0, true, false), (8, 16, 32, 33, 128, 256))...,
-    map(n -> tuple_of_tuples(n, 1, true, false), (8, 16, 32, 33, 128, 256))...,
-    map(n -> tuple_of_tuples(n, 1, false, false), (8, 16, 32, 33, 128, 256))...,
+    map(n -> tuple_of_tuples(n, 0, true, true), gen_vs_rec_itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, true, true), gen_vs_rec_itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, false, true), gen_vs_rec_itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 0, true, false), gen_vs_rec_itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, true, false), gen_vs_rec_itr_lengths)...,
+    map(n -> tuple_of_tuples(n, 1, false, false), gen_vs_rec_itr_lengths)...,
 )
     str = tuples_of_tuples_contents_str(itr)
     itr_description = "a Tuple that contains $(length(itr)) $str"
     @testset "generative vs. recursive unrolling of $itr_description" begin
+        @test_unrolled(
+            (itr,),
+            UnrolledUtilities.gen_unrolled_map(length, itr),
+            UnrolledUtilities.rec_unrolled_map(length, itr),
+            str,
+        )
+
         @test_unrolled(
             (itr,),
             UnrolledUtilities.gen_unrolled_any(isempty, itr),
@@ -932,29 +1155,7 @@ for itr in (
             str,
         )
 
-        @test_unrolled(
-            (itr,),
-            UnrolledUtilities.gen_unrolled_map(length, itr),
-            UnrolledUtilities.rec_unrolled_map(length, itr),
-            str,
-        )
-
-        @test_unrolled(
-            (itr,),
-            UnrolledUtilities.gen_unrolled_applyat(
-                length,
-                rand(1:7:length(itr)),
-                itr,
-            ),
-            UnrolledUtilities.rec_unrolled_applyat(
-                length,
-                rand(1:7:length(itr)),
-                itr,
-            ),
-            str,
-        )
-
-        if length(itr) <= 33
+        if length(itr) <= 32
             @test_unrolled(
                 (itr,),
                 UnrolledUtilities.gen_unrolled_reduce(tuple, itr, ()),
@@ -964,18 +1165,8 @@ for itr in (
 
             @test_unrolled(
                 (itr,),
-                UnrolledUtilities.gen_unrolled_accumulate(
-                    tuple,
-                    itr,
-                    (),
-                    identity,
-                ),
-                UnrolledUtilities.rec_unrolled_accumulate(
-                    tuple,
-                    itr,
-                    (),
-                    identity,
-                ),
+                UnrolledUtilities.gen_unrolled_accumulate(tuple, itr, ()),
+                UnrolledUtilities.rec_unrolled_accumulate(tuple, itr, ()),
                 str,
             )
         end # These can take over a minute to compile when the length is 128.


### PR DESCRIPTION
This PR extends UnrolledUtilities so that it can more easily be used throughout CliMA's codebase, and also fixes some lingering issues with the internals and documentation. UnrolledUtilities should now be able to replace every instance of manual loop unrolling in ClimaCore without any deterioration in run time or compilation time, and hopefully its documentation and comments are sufficiently clear for new users.

## Content
- Changes to interface
  - Add unrolled analogues of more functions from `Base` and `Base.Iterators`:
    - Add `unrolled_prepend` as an alternative to `unrolled_append`
    - Add `unrolled_allunique` and `unrolled_allequal`, so that we have an analogue of every exported function from `base/set.jl` that is defined for generic iterators
    -  Add `unrolled_sum`, `unrolled_prod`, `unrolled_count`, `unrolled_maximum`, `unrolled_minimum`, `unrolled_extrema`, `unrolled_findmax`, `unrolled_findmin`, `unrolled_argmax`, and `unrolled_argmin`, so that we have an analogue of every exported function from `base/reduce.jl`
    - Add `unrolled_cumsum` and `unrolled_cumprod`, so that we have an analogue of every exported function from `base/accumulate.jl`
    - Add `unrolled_cycle` and `unrolled_partition`, so that we have an analogue of every exported function from `base/iterators.jl` that is useful for fixed-size iterators
  - Add support for `Base.Iterators.Reverse`, so that `Iterators.reverse(itr)` can be passed to unrolled functions
  - Simplify `unrolled_accumulate` by removing the optional `transform` argument, as it isn't necessary or useful
- Changes to internals
  - Modify `rec_unroll` so that recursive loop unrolling is used for iterators up to length 2
    - This choice minimizes compilation time across all use cases tested in the final comparison table
  - Rewrite `unrolled_product` so that it computes indices into iterators instead of repeatedly calling `unrolled_push`
    - When the iterators passed to `unrolled_product` have large lengths, this improves runtime at the cost of slightly higher compilation time and memory usage
    - This fixes a longstanding issue where the runtime of `unrolled_product` was slower than the runtime of `product` for large iterators
  - Generalize the internal implementation of `unrolled_applyat` to `unrolled_ifelse`, and use this to define `unrolled_findfirst`, `unrolled_findlast`, `unrolled_argfirst`, and `unrolled_arglast`
    - Although `unrolled_findfirst` and its counterparts can also be implemented in terms of `unrolled_reduce`, that version takes significantly longer to compile
    - This generalization allows `unrolled_findfirst` and its counterparts to be compiled relatively quickly without needing to add more generated functions
    - The only downside is that this slightly slows down the compilation of `unrolled_applyat`, since it requires an additional level of inlining
  - Replace the internal implementation of `unrolled_append` with `Base.ntuple`
    - This improves type stability for lazy iterators with more than 32 elements
  - Add a simplified version of `∘` with improved type stability for internal use
  - Simplify the computations of `output_type` for lazy iterators by removing duplicated code and using argument splatting
  - Simplify `_gen_unrolled_reduce` by making it more similar to `_gen_unrolled_accumulate`
- Changes to documentation
  - Add documentation for all new unrolled functions to `index.md`
  - Add a docstring for `StaticSequence` and update the documentation for `rec_unroll` in `developer_guide.md`
  - Remove the example in `introduction.md` that was used to illustrate the runtime issue with `unrolled_product`
  - Update the examples in `user_guide.md` to reflect changes from Julia 1.10 to 1.11
  - Make the package summary in `README.md` more engaging and noteworthy (as suggested by @Sbozzolo)
  - Reorganize `src/UnrolledUtilities.jl` and add comments to explain the different sections of code
- Changes to CI
  - Reduce the time required for CI
    - Replace the `julia-runtest` action in `ci.yml` with `Pkg.test()`, speeding up CI by more than a factor of 3
    - Remove the `cache` action from `ci.yml`, since there aren't any artifacts to cache
    - Simplify the `CodeCov.yml` workflow, and add a `fast_mode` flag to ensure that it is at least as fast as `ci.yml`
  - Update all workflows to use the latest version of Julia 1.11
  - Add unit tests for all new unrolled functions
  - Small improvements to the comparison tables
    - Add information about LLVM line count and switch instructions
    - Fix false positives/negatives due to imprecisions in `time_ns`
    - Use consistent iterator lengths for benchmarking