### PR TITLE
Fix recursion instability in unrolled_product

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnrolledUtilities"
 uuid = "0fe1646c-419e-43be-ac14-22321958931b"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.7"
+version = "0.1.8"
 
 [compat]
 julia = "1.9"

--- a/src/UnrolledUtilities.jl
+++ b/src/UnrolledUtilities.jl
@@ -399,8 +399,10 @@ include("generatively_unrolled_functions.jl")
 @inline unrolled_product(itrs...) =
     ntuple(Val(unrolled_prod(length, itrs))) do n
         @inline
+        Base.@assume_effects :foldable
         items = ntuple(Val(length(itrs))) do itr_index
             @inline
+            Base.@assume_effects :foldable
             cur_length = length(itrs[itr_index])
             prev_length = unrolled_prod(length, itrs[1:(itr_index - 1)])
             item_index = (n - 1) ÷ prev_length % cur_length + 1


### PR DESCRIPTION
This PR fixes type stabilities in the ClimaCore unit tests that were introduced by changes to `unrolled_product` in #21. It does this by adding `Base.@assume_effects :foldable` annotations to the function closures in `unrolled_product`, ensuring that the compiler does not trigger the recursion limit when performing unrolled operations in ClimaCore's `MatrixFields` module.

In the future, we will probably want to generalize this to all function closures in UnrolledUtilities. Unfortunately, there does not seem to be a good way to automate this (unlike for regular `Function`s, whose recursion limits are already disabled by UnrolledUtilities), so we will need to manually add these compiler annotations to every `do ... end` block.

Unfortunately, the compiler seems to ignore the annotations when testing code coverage. I have no idea how to fix this, so for now I've just disabled the allocations test for `unrolled_product` when testing code coverage.

While experimenting with this PR, I also found that we can occasionally get false negatives in the benchmark tests for constant propagation on Julia 1.11, so I've modified how we measure `rettype_const` to avoid this.

Closes: CliMA/ClimaCore.jl#2217