### PR TITLE
Revert to 0.1.6

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -1,4 +1,5 @@
 name: CodeCov
+
 on:
   push:
     branches:
@@ -8,20 +9,35 @@ on:
   merge_group:
 
 jobs:
-  test:
-    name: CodeCov
+  codecov:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
-        with:
-          version: 1.11
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          test_args: 'fast_mode' # Testing with code coverage is very slow.
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v5
-        with:
-          file: lcov.info
-          token: ${{secrets.CODECOV_TOKEN}}
+    - uses: actions/checkout@v4
+
+    - name: Set up Julia
+      uses: julia-actions/setup-julia@latest
+      with:
+        version: '1.10'
+
+    - name: Test with coverage
+      env:
+        JULIA_PROJECT: "@."
+      run: |
+        julia --project=@. -e 'using Pkg; Pkg.instantiate()'
+        julia --project=@. -e 'using Pkg; Pkg.test(coverage=true)'
+
+    - name: Generate coverage file
+      env:
+        JULIA_PROJECT: "@."
+      run: julia --project=@. -e 'using Pkg; Pkg.add("Coverage");
+                                  using Coverage;
+                                  LCOV.writefile("coverage-lcov.info", Codecov.process_folder())'
+      if: success()
+
+    - name: Submit coverage
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{secrets.CODECOV_TOKEN}}
+      if: success()
+

--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
-          version: '1.11'
+          version: '1.10'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -30,7 +30,7 @@ jobs:
     - uses: julia-actions/setup-julia@latest
       if: steps.filter.outputs.julia_file_change == 'true'
       with:
-        version: '1.11'
+        version: '1.10'
 
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,37 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.11'
+          - '~1.11.0-0'
         os:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
+        arch:
+          - x64
+        exclude:
+          - version: '~1.11.0-0'
+            os: macOS-latest # JET crashes on one unit test and hangs on another
+          - version: '~1.11.0-0'
+            os: windows-latest # JET crashes on 3 unit tests
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v1
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-test-${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
-      - name: Run tests
-        run: julia --project -e 'using Pkg; Pkg.test(; coverage = false)'
-        # Using the julia-runtest action makes this more than 2 times slower.
+      - uses: julia-actions/julia-runtest@v1
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v1
+        with:
+          file: lcov.info

--- a/.github/workflows/invalidations.yml
+++ b/.github/workflows/invalidations.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - uses: julia-actions/setup-julia@v1
       with:
-        version: '1.11'
+        version: '1.10' # JET and SnoopCompile do not yet support Julia 1.11
     - uses: actions/checkout@v4
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnrolledUtilities"
 uuid = "0fe1646c-419e-43be-ac14-22321958931b"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.6"
+version = "0.1.8"
 
 [compat]
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "UnrolledUtilities"
 uuid = "0fe1646c-419e-43be-ac14-22321958931b"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
-version = "0.1.7"
+version = "0.1.6"
 
 [compat]
 julia = "1.9"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@
 </picture>
 </h1>
 
-Are you feeling type unstable? Struggling to compile code for GPUs? Do you find yourself with more allocations than FLOPS?
-
-Ask your developer if *UnrolledUtilities.jl* is right for you.
+A toolkit for optimizing Julia code that uses statically sized iterators.
 
 |||
 |---------------------:|:----------------------------------------------|

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -29,7 +29,14 @@ following function:
 rec_unroll
 ```
 
-The default choice for `rec_unroll` is motivated by the benchmarks for
+!!! tip "Tip"
+    Recursive loop unrolling can be enabled by redefining this function:
+
+    ```julia
+    rec_unroll(itr) = true
+    ```
+
+The default choice of generative unrolling is motivated by the benchmarks for
 [Generative vs. Recursive Unrolling](@ref).
 
 ## Interface API
@@ -47,7 +54,6 @@ ConditionalOutputType
 output_promote_rule
 constructor_from_tuple
 empty_output
-StaticSequence
 ```
 
 ## How to Use the Interface
@@ -77,12 +83,12 @@ these steps:
           be implemented to construct an iterator of type `U` without first
           storing the iterator's contents in a `Tuple`:
             - `empty_output(U)`
+            - `unrolled_map_into(U, f, itr)`
+            - `unrolled_accumulate_into(U, op, itr, init, transform)`
             - `unrolled_push_into(U, itr, item)`
             - `unrolled_append_into(U, itr1, itr2)`
             - `unrolled_take_into(U, itr, val_N)`
             - `unrolled_drop_into(U, itr, val_N)`
-            - `unrolled_map_into(U, f, itr)`
-            - `unrolled_accumulate_into(U, op, itr, init, transform)`
 
 !!! note "Note"
     When a relevant method for the interface is not defined, unrolled functions

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,11 +15,8 @@ inefficiently. For example, the standard libary function `in` performs worse
 than this package's `unrolled_in` for `Tuple`s with elements of different types:
 
 ```@repl inference_test
-nonuniform_itr = ((1, 2), (1, 2, 3));
-() in nonuniform_itr # hide
-@allocated () in nonuniform_itr
-unrolled_in((), nonuniform_itr) # hide
-@allocated unrolled_in((), nonuniform_itr)
+@allocated () in ((1, 2), (1, 2, 3))
+@allocated unrolled_in((), ((1, 2), (1, 2, 3)))
 ```
 
 The [loop unrolling](https://en.wikipedia.org/wiki/Loop_unrolling) automatically
@@ -43,64 +40,40 @@ To find out more about loop unrolling and when it is useful, see the
 This package exports a number of analogues to functions from `Base` and
 `Base.Iterators`, each of which has been optimized for statically sized
 iterators (in terms of both performance and compilation time):
-- `unrolled_push(itr, item)`—similar to `push!`, but non-mutating
-- `unrolled_append(itr, itrs...)`—similar to `append!`, but non-mutating
-- `unrolled_prepend(itr, itrs...)`—similar to `prepend!`, but non-mutating
-- `unrolled_map(f, itrs...)`—similar to `map`
-- `unrolled_any([f], itr)`—similar to `any`
-- `unrolled_all([f], itr)`—similar to `all`
+- `unrolled_any(f, itr)`—similar to `any`
+- `unrolled_all(f, itr)`—similar to `all`
 - `unrolled_foreach(f, itrs...)`—similar to `foreach`
-- `unrolled_reduce(op, itr; [init])`—similar to `reduce` (i.e., `foldl`)
-- `unrolled_mapreduce(f, op, itrs...; [init])`—similar to `mapreduce` (i.e.,
-  `mapfoldl`)
-- `unrolled_accumulate(op, itr; [init])`—similar to `accumulate`
+- `unrolled_map(f, itrs...)`—similar to `map`
+- `unrolled_reduce(op, itr; [init])`—similar to `reduce`
+- `unrolled_mapreduce(f, op, itrs...; [init])`—similar to `mapreduce`
+- `unrolled_accumulate(op, itr; [init], [transform])`—similar to `accumulate`,
+  but with a `transform` that can be applied to every value in the output
+- `unrolled_push(itr, item)`—similar to `push!`, but non-mutating
+- `unrolled_append(itr1, itr2)`—similar to `append!`, but non-mutating
+- `unrolled_take(itr, ::Val{N})`—similar to `Iterators.take` (i.e., `itr[1:N]`),
+  but with `N` wrapped in a `Val`
+- `unrolled_drop(itr, ::Val{N})`—similar to `Iterators.drop` (i.e.,
+  `itr[(N + 1):end]`), but with `N` wrapped in a `Val`
 - `unrolled_in(item, itr)`—similar to `in`
-- `unrolled_unique([f], itr)`—similar to `unique`
-- `unrolled_allunique([f], itr)`—similar to `allunique`
-- `unrolled_allequal([f], itr)`—similar to `allequal`
-- `unrolled_sum([f], itr; [init])`—similar to `sum`, but with `init = 0` when
-  `itr` is empty
-- `unrolled_prod([f], itr; [init])`—similar to `prod`, but with `init = 1` when
-  `itr` is empty
-- `unrolled_cumsum([f], itr)`—similar to `cumsum`, but with an optional `f`
-- `unrolled_cumprod([f], itr)`—similar to `cumprod`, but with an optional `f`
-- `unrolled_count([f], itr)`—similar to `count`
-- `unrolled_maximum([f], itr)`—similar to `maximum`
-- `unrolled_minimum([f], itr)`—similar to `minimum`
-- `unrolled_extrema([f], itr)`—similar to `extrema`
-- `unrolled_findmax([f], itr)`—similar to `findmax`
-- `unrolled_findmin([f], itr)`—similar to `findmin`
-- `unrolled_argmax([f], itr)`—similar to `argmax`
-- `unrolled_argmin([f], itr)`—similar to `argmin`
-- `unrolled_findfirst([f], itr)`—similar to `findfirst`
-- `unrolled_findlast([f], itr)`—similar to `findlast`
+- `unrolled_unique(itr)`—similar to `unique`
 - `unrolled_filter(f, itr)`—similar to `filter`
 - `unrolled_flatten(itr)`—similar to `Iterators.flatten`
 - `unrolled_flatmap(f, itrs...)`—similar to `Iterators.flatmap`
 - `unrolled_product(itrs...)`—similar to `Iterators.product`
-- `unrolled_cycle(itr, ::Val{N})`—similar to `Iterators.cycle`, but with a
-  static value of `N`
-- `unrolled_partition(itr, ::Val{N})`—similar to `Iterators.partition`, but with
-  a static value of `N`
-- `unrolled_take(itr, ::Val{N})`—similar to `Iterators.take` (i.e., `itr[1:N]`),
-  but with a static value of `N`
-- `unrolled_drop(itr, ::Val{N})`—similar to `Iterators.drop` (i.e.,
-  `itr[(N + 1):end]`), but with a static value of `N`
 
-In addition, this package exports several functions that do not have analogues
-in `Base` or `Base.Iterators`:
-- `unrolled_applyat(f, n, itrs...)`—similar to `f(itrs[1][n], itrs[2][n], ...)`
-- `unrolled_argfirst(f, itr)`—similar to `itr[findfirst(f, itr)]`
-- `unrolled_arglast(f, itr)`—similar to `itr[findlast(f, itr)]`
+In addition, this package exports two functions that do not have public
+analogues in `Base` or `Base.Iterators`:
+- `unrolled_applyat(f, n, itrs...)`—similar to `f(itrs[1][n], itrs[2][n], ...)`,
+  but with a `Core.Const` index in every call to `getindex`
 - `unrolled_split(f, itr)`—similar to `(filter(f, itr), filter(!f, itr))`, but
   without duplicate calls to `f`
 
 These unrolled functions are compatible with the following types of iterators:
 - statically sized iterators from `Base` (e.g., `Tuple` and `NamedTuple`)
 - statically sized iterators from `StaticArrays` (e.g., `SVector` and `MVector`)
-- lazy iterators from `Base` (e.g., the results of generator expressions,
-  `Iterators.map`, `Iterators.reverse`, `enumerate`, and `zip`) that are used as
-  wrappers for statically sized iterators
+- lazy iterators from `Base` (e.g., the results of `enumerate`, `zip`,
+  `Iterators.map`, and generator expressions) that are used as wrappers for
+  statically sized iterators
 
 They are also compatible with two new types of statically sized iterators
 exported by this package:

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -208,12 +208,17 @@ hand, here is the LLVM code for the non-unrolled version of this loop:
 @code_llvm debuginfo=:none foreach(println, Tuple(1:33))
 ```
 
-This LLVM code has a `load` instruction to get the first value and a
-`getelementptr` instruction with a non-constant integer index to get all other
-values. It also has conditional jump instructions for checking whether the last
-index has been reached after each `load` and `getelementptr` instruction.
+Although the first `getelementptr` instruction here has the constant index 0,
+the other `getelementptr` instruction has a non-constant integer index. Also,
+this LLVM code has conditional jump instructions for checking whether the last
+index of the `Tuple` has been reached after each `getelementptr` instruction.
 
 ## Downsides of Loop Unrolling
+
+```@setup tuple_of_tuples_test
+using UnrolledUtilities, Test
+tup32 = ntuple(Returns((1, 2)), 32)
+```
 
 Given the performance benefits of loop unrolling, it might seem at first that
 the standard library needs more of it. However, the standard library is not just
@@ -225,7 +230,7 @@ occasionally be faster to compile than non-unrolled functions, they are
 typically slower to compile, which means that using them instead of standard
 library functions can often increase total execution time:
 
-```@repl inference_test
+```@repl tuple_of_tuples_test
 tup32 = ntuple(Returns((1, 2)), 32);
 @elapsed map(first, tup32)
 @elapsed unrolled_map(first, tup32)
@@ -234,16 +239,30 @@ tup32 = ntuple(Returns((1, 2)), 32);
 The increase in compilation time is usually no more than a factor of 5 for small
 iterators, but it grows as iterator length increases:
 
-```@repl inference_test
+```@repl tuple_of_tuples_test
 tup320 = ntuple(Returns((1, 2)), 320);
 @elapsed map(first, tup320)
 @elapsed unrolled_map(first, tup320)
 ```
 
-Loop unrolling can also theoretically increase the run time of a function in
-addition to its compilation time, since unrolled assembly code requires more
-space and takes longer to load than non-unrolled code. In practice, though, the
-constant propagation enabled by unrolling usually compensates for this slowdown.
+Moreover, loop unrolling can sometimes increase the run time of a function in
+addition to its compilation time:
+
+```@repl tuple_of_tuples_test
+@elapsed Tuple(Iterators.product(tup32, tup32)) # compilation time + run time
+@elapsed Tuple(Iterators.product(tup32, tup32)) # only run time
+@elapsed unrolled_product(tup32, tup32) # compilation time + run time
+@elapsed unrolled_product(tup32, tup32) # only run time
+```
+
+This increase in run time is most likely due to the larger size of unrolled
+code, which makes it take longer to load. Nevertheless, loop unrolling still
+offers the benefit of eliminating the unstable return type in this example:
+
+```@repl tuple_of_tuples_test
+Test.@inferred Tuple(Iterators.product(tup32, tup32));
+Test.@inferred unrolled_product(tup32, tup32);
+```
 
 So, when type instabilities and memory allocations need to be removed
 ([as is required for static compilation](https://github.com/brenhinkeller/StaticTools.jl#limitations))

--- a/src/UnrolledUtilities.jl
+++ b/src/UnrolledUtilities.jl
@@ -1,120 +1,125 @@
 module UnrolledUtilities
 
-export StaticSequence,
-    StaticOneTo,
-    StaticBitVector,
-    unrolled_push,
-    unrolled_append,
-    unrolled_prepend,
-    unrolled_take,
-    unrolled_drop,
-    unrolled_map,
-    unrolled_any,
+export unrolled_any,
     unrolled_all,
     unrolled_foreach,
+    unrolled_map,
+    unrolled_applyat,
     unrolled_reduce,
     unrolled_mapreduce,
     unrolled_accumulate,
-    unrolled_applyat,
+    unrolled_push,
+    unrolled_append,
+    unrolled_take,
+    unrolled_drop,
     unrolled_in,
     unrolled_unique,
-    unrolled_allunique,
-    unrolled_allequal,
-    unrolled_sum,
-    unrolled_prod,
-    unrolled_cumsum,
-    unrolled_cumprod,
-    unrolled_count,
-    unrolled_maximum,
-    unrolled_minimum,
-    unrolled_extrema,
-    unrolled_findmax,
-    unrolled_findmin,
-    unrolled_argmax,
-    unrolled_argmin,
-    unrolled_findfirst,
-    unrolled_findlast,
-    unrolled_argfirst,
-    unrolled_arglast,
     unrolled_filter,
     unrolled_split,
     unrolled_flatten,
     unrolled_flatmap,
     unrolled_product,
-    unrolled_cycle,
-    unrolled_partition
+    StaticOneTo,
+    StaticBitVector
 
-##
-## Internal types and functions
-##
+struct NoInit end # Analogue of Base._InitialValue for reduction/accumulation.
 
 include("unrollable_iterator_interface.jl")
+include("recursively_unrolled_functions.jl")
+include("generatively_unrolled_functions.jl")
 
-# Analogue of the non-public Base._InitialValue for reduction and accumulation.
-struct NoInit end
+@inline unrolled_any(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_any : gen_unrolled_any)(f, itr)
+@inline unrolled_any(itr) = unrolled_any(identity, itr)
 
-# Analogue of ∘, but with only one function argument and guaranteed inlining.
-# Base's ∘ leads to type instabilities in unit tests on Julia 1.10 and 1.11.
-@inline ⋅(f1::F1, f2::F2) where {F1, F2} = x -> (@inline f1(f2(x)))
-@inline ⋅(::Type{T}, f::F) where {T, F} = x -> (@inline T(f(x)))
-@inline ⋅(f::F, ::Type{T}) where {F, T} = x -> (@inline f(T(x)))
-@inline ⋅(::Type{T1}, ::Type{T2}) where {T1, T2} = x -> (@inline T1(T2(x)))
+@inline unrolled_all(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_all : gen_unrolled_all)(f, itr)
+@inline unrolled_all(itr) = unrolled_all(identity, itr)
 
-##
-## Types with optimized methods for unrolled functions
-##
+@inline unrolled_foreach(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_foreach : gen_unrolled_foreach)(f, itr)
+@inline unrolled_foreach(f, itrs...) = unrolled_foreach(splat(f), zip(itrs...))
 
-"""
-    StaticSequence{N}
+@inline unrolled_map_into_tuple(f::F, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_map : gen_unrolled_map)(f, itr)
+@inline unrolled_map_into(output_type, f::F, itr) where {F} =
+    constructor_from_tuple(output_type)(unrolled_map_into_tuple(f, itr))
+@inline unrolled_map(f::F, itr) where {F} =
+    unrolled_map_into(inferred_output_type(Iterators.map(f, itr)), f, itr)
+@inline unrolled_map(f::F, itrs...) where {F} =
+    unrolled_map(splat(f), zip(itrs...))
 
-Abstract type that can represent any iterable of constant length `N`. Subtypes
-include the low-storage data structures `StaticOneTo` and `StaticBitVector`,
-which have optimized methods for certain unrolled functions.
-"""
-abstract type StaticSequence{N} end
+@inline unrolled_applyat(f::F, n, itr) where {F} =
+    (rec_unroll(itr) ? rec_unrolled_applyat : gen_unrolled_applyat)(f, n, itr)
+@inline unrolled_applyat(f::F, n, itrs...) where {F} =
+    unrolled_applyat(splat(f), n, zip(itrs...))
+@inline unrolled_applyat_bounds_error() =
+    error("unrolled_applyat has detected an out-of-bounds index")
 
-@inline Base.length(::StaticSequence{N}) where {N} = N
-@inline Base.firstindex(::StaticSequence) = 1
-@inline Base.lastindex(itr::StaticSequence) = length(itr)
-@inline Base.getindex(itr::StaticSequence, n::Integer) =
-    generic_getindex(itr, n)
-@inline Base.iterate(itr::StaticSequence, n = 1) =
-    n > length(itr) ? nothing : (generic_getindex(itr, n), n + 1)
-@inline Base.iterate(
-    itr::Iterators.Reverse{<:StaticSequence},
-    n = length(itr),
-) = n < 1 ? nothing : (generic_getindex(itr.itr, n), n - 1)
+@inline unrolled_reduce(op::O, itr, init) where {O} =
+    isempty(itr) && init isa NoInit ?
+    error("unrolled_reduce requires an init value for empty iterators") :
+    (rec_unroll(itr) ? rec_unrolled_reduce : gen_unrolled_reduce)(op, itr, init)
+@inline unrolled_reduce(op::O, itr; init = NoInit()) where {O} =
+    unrolled_reduce(op, itr, init)
 
-include("StaticOneTo.jl")
-include("StaticBitVector.jl")
+# TODO: Figure out why unrolled_reduce(op, Val(N), init) compiles faster than
+# unrolled_reduce(op, StaticOneTo(N), init) for the non-orographic gravity wave
+# parametrization test in ClimaAtmos, to the point where the StaticOneTo version
+# completely hangs while the Val version compiles in only a few seconds.
+@inline unrolled_reduce(op::O, val_N::Val, init) where {O} =
+    val_N isa Val{0} && init isa NoInit ?
+    error("unrolled_reduce requires an init value for Val(0)") :
+    val_unrolled_reduce(op, val_N, init)
 
-@inline static_range(itr) = StaticOneTo(length(itr))
+@inline unrolled_mapreduce(f::F, op::O, itrs...; init = NoInit()) where {F, O} =
+    unrolled_reduce(op, unrolled_map(f, itrs...), init)
 
-##
-## Functions unrolled using either Core.tuple or ntuple
-##
+@inline unrolled_accumulate_into_tuple(
+    op::O,
+    itr,
+    init,
+    transform::T,
+) where {O, T} =
+    (rec_unroll(itr) ? rec_unrolled_accumulate : gen_unrolled_accumulate)(
+        op,
+        itr,
+        init,
+        transform,
+    )
+@inline unrolled_accumulate_into(
+    output_type,
+    op::O,
+    itr,
+    init,
+    transform::T,
+) where {O, T} = constructor_from_tuple(output_type)(
+    unrolled_accumulate_into_tuple(op, itr, init, transform),
+)
+@inline unrolled_accumulate(op::O, itr, init, transform::T) where {O, T} =
+    unrolled_accumulate_into(
+        accumulate_output_type(op, itr, init, transform),
+        op,
+        itr,
+        init,
+        transform,
+    )
+@inline unrolled_accumulate(
+    op::O,
+    itr;
+    init = NoInit(),
+    transform::T = identity,
+) where {O, T} = unrolled_accumulate(op, itr, init, transform)
 
 @inline unrolled_push_into(output_type, itr, item) =
     constructor_from_tuple(output_type)((itr..., item))
 @inline unrolled_push(itr, item) =
     unrolled_push_into(inferred_output_type(itr), itr, item)
-@inline unrolled_push(itr, items...) =
-    unrolled_reduce(unrolled_push, items, itr)
 
 @inline unrolled_append_into(output_type, itr1, itr2) =
-    constructor_from_tuple(output_type)(
-        ntuple(Val(length(itr1) + length(itr2))) do n
-            @inline
-            n <= length(itr1) ? generic_getindex(itr1, n) :
-            generic_getindex(itr2, n - length(itr1))
-        end,
-    )
+    constructor_from_tuple(output_type)((itr1..., itr2...))
 @inline unrolled_append(itr1, itr2) =
-    unrolled_append_into(promoted_output_type(itr1, itr2), itr1, itr2)
-@inline unrolled_append(itr, itrs...) =
-    unrolled_reduce(unrolled_append, itrs, itr)
-
-@inline unrolled_prepend(itr, itrs...) = unrolled_append(itrs..., itr)
+    unrolled_append_into(promoted_output_type((itr1, itr2)), itr1, itr2)
 
 @inline unrolled_take_into(output_type, itr, ::Val{N}) where {N} =
     constructor_from_tuple(output_type)(
@@ -125,244 +130,20 @@ include("StaticBitVector.jl")
 
 @inline unrolled_drop_into(output_type, itr, ::Val{N}) where {N} =
     constructor_from_tuple(output_type)(
-        ntuple(
-            Base.Fix1(generic_getindex, itr) ⋅ Base.Fix1(+, N),
-            Val(length(itr) - N),
-        ),
+        ntuple(n -> generic_getindex(itr, N + n), Val(length(itr) - N)),
     )
 @inline unrolled_drop(itr, val_N) =
     unrolled_drop_into(inferred_output_type(itr), itr, val_N)
 
-##
-## Functions unrolled using either recursion or generated expressions
-##
-
-include("recursively_unrolled_functions.jl")
-include("generatively_unrolled_functions.jl")
-
-# The unrolled_map function could also be implemented in terms of ntuple, but
-# then it would be subject to the same recursion limit as ntuple. On Julia 1.10,
-# this leads to type instabilities in several unit tests for nested iterators.
-@inline unrolled_map_into_tuple(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_map : gen_unrolled_map)(f, itr)
-@inline unrolled_map_into(output_type, f::F, itr) where {F} =
-    constructor_from_tuple(output_type)(unrolled_map_into_tuple(f, itr))
-@inline unrolled_map(f::F, itr) where {F} =
-    unrolled_map_into(inferred_output_type(Iterators.map(f, itr)), f, itr)
-@inline unrolled_map(f::F, itrs...) where {F} =
-    unrolled_map(splat(f), zip(itrs...))
-
-@inline unrolled_any(itr) = unrolled_any(identity, itr)
-@inline unrolled_any(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_any : gen_unrolled_any)(f, itr)
-
-@inline unrolled_all(itr) = unrolled_all(identity, itr)
-@inline unrolled_all(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_all : gen_unrolled_all)(f, itr)
-
-@inline unrolled_foreach(f::F, itr) where {F} =
-    (rec_unroll(itr) ? rec_unrolled_foreach : gen_unrolled_foreach)(f, itr)
-@inline unrolled_foreach(f, itrs...) = unrolled_foreach(splat(f), zip(itrs...))
-
-@inline unrolled_reduce(op::O, itr, init) where {O} =
-    isempty(itr) && init isa NoInit ?
-    error("unrolled_reduce requires an init value for empty iterators") :
-    (rec_unroll(itr) ? rec_unrolled_reduce : gen_unrolled_reduce)(op, itr, init)
-@inline unrolled_reduce(op::O, itr; init = NoInit()) where {O} =
-    unrolled_reduce(op, itr, init)
-
-@inline unrolled_mapreduce(f::F, op::O, itrs...; init = NoInit()) where {F, O} =
-    unrolled_reduce(op, unrolled_map(f, itrs...), init)
-
-@inline unrolled_accumulate_into_tuple(op::O, itr, init) where {O} =
-    (rec_unroll(itr) ? rec_unrolled_accumulate : gen_unrolled_accumulate)(
-        op,
-        itr,
-        init,
-    )
-@inline unrolled_accumulate_into(output_type, op::O, itr, init) where {O} =
-    constructor_from_tuple(output_type)(
-        unrolled_accumulate_into_tuple(op, itr, init),
-    )
-@inline unrolled_accumulate(op::O, itr, init) where {O} =
-    unrolled_accumulate_into(
-        unrolled_accumulate_output_type(op, itr, init),
-        op,
-        itr,
-        init,
-    )
-@inline unrolled_accumulate(op::O, itr; init = NoInit()) where {O} =
-    unrolled_accumulate(op, itr, init)
-
-# The unrolled_ifelse function is for internal use, and it is not exported.
-# With one iterator as an argument, it is similar to
-# f(itr[1]) ? get_if(itr[1]) : f(itr[2]) ? get_if(itr[2]) ... : get_else().
-# With two iterators as arguments, it is similar to
-# f(itr1[1]) ? get_if(itr2[1]) : f(itr1[2]) ? get_if(itr2[2]) ... : get_else().
-# When f compares a constant isbits value computed from each item against a
-# non-constant isbits value (as in unrolled_applyat), unrolled_ifelse is
-# optimized into a switch instruction during LLVM code generation.
-@inline unrolled_ifelse(
-    f::F,
-    get_if::I,
-    get_else::E,
-    itr,
-    itrs...,
-) where {F, I, E} =
-    (rec_unroll(itr) ? rec_unrolled_ifelse : gen_unrolled_ifelse)(
-        f,
-        get_if,
-        get_else,
-        itr,
-        itrs...,
-    )
-
-##
-## Unrolled functions without any analogues in Base
-##
-
-@inline unrolled_applyat(f::F, n, itr) where {F} = unrolled_ifelse(
-    ==(n),
-    f,
-    () -> throw(BoundsError(itr, n)),
-    static_range(itr),
-    itr,
-)
-@inline unrolled_applyat(f::F, n, itrs...) where {F} =
-    unrolled_applyat(splat(f), n, zip(itrs...))
-
-##
-## Unrolled analogues of functions from base/operators.jl and base/set.jl
-##
-
+@inline unrolled_in(item, itr) = unrolled_any(Base.Fix1(===, item), itr)
 # Using === instead of == or isequal improves type stability for singletons.
 
-@inline unrolled_in(item, itr) = unrolled_any(Base.Fix1(===, item), itr)
-
 @inline unrolled_unique(itr) =
-    unrolled_reduce(itr, inferred_empty(itr)) do items, item
+    unrolled_reduce(itr, inferred_empty(itr)) do unique_items, item
         @inline
-        unrolled_in(item, items) ? items : unrolled_push(items, item)
+        unrolled_in(item, unique_items) ? unique_items :
+        unrolled_push(unique_items, item)
     end
-@inline unrolled_unique(f::F, itr) where {F} =
-    unrolled_reduce(itr, ((), inferred_empty(itr))) do (f_values, items), item
-        @inline
-        f_value = f(item)
-        unrolled_in(f_value, f_values) ? (f_values, items) :
-        (unrolled_push(f_values, f_value), unrolled_push(items, item))
-    end[2]
-
-@inline unrolled_allunique(itr) = unrolled_allunique(identity, itr)
-@inline unrolled_allunique(f::F, itr) where {F} =
-    length(itr) == length(unrolled_unique(f, itr))
-
-@inline unrolled_allequal(itr) = unrolled_allequal(identity, itr)
-@inline unrolled_allequal(f::F, itr) where {F} =
-    isempty(itr) ? true :
-    unrolled_all(
-        Base.Fix1(===, f(generic_getindex(itr, 1))) ⋅ f,
-        unrolled_drop(itr, Val(1)),
-    )
-
-##
-## Unrolled analogues of functions from base/reduce.jl and base/accumulate.jl
-##
-
-# Sum and prod only need init when itr is empty, so it can be ignored otherwise.
-
-@inline unrolled_sum(itr; init = 0) = unrolled_sum(identity, itr; init)
-@inline unrolled_sum(f::F, itr; init = 0) where {F} =
-    isempty(itr) ? init : unrolled_mapreduce(f, +, itr)
-
-@inline unrolled_prod(itr; init = 1) = unrolled_prod(identity, itr; init)
-@inline unrolled_prod(f::F, itr; init = 1) where {F} =
-    isempty(itr) ? init : unrolled_mapreduce(f, *, itr)
-
-@inline unrolled_cumsum(itr) = unrolled_cumsum(identity, itr)
-@inline unrolled_cumsum(f::F, itr) where {F} =
-    unrolled_accumulate(+, unrolled_map(f, itr))
-
-@inline unrolled_cumprod(itr) = unrolled_cumprod(identity, itr)
-@inline unrolled_cumprod(f::F, itr) where {F} =
-    unrolled_accumulate(*, unrolled_map(f, itr))
-
-@inline unrolled_count(itr) = unrolled_count(identity, itr)
-@inline unrolled_count(f::F, itr) where {F} = unrolled_sum(Bool ⋅ f, itr)
-
-@inline unrolled_maximum(itr) = unrolled_maximum(identity, itr)
-@inline unrolled_maximum(f::F, itr) where {F} = unrolled_mapreduce(f, max, itr)
-
-@inline unrolled_minimum(itr) = unrolled_minimum(identity, itr)
-@inline unrolled_minimum(f::F, itr) where {F} = unrolled_mapreduce(f, min, itr)
-
-@inline extrema_reduction_operator((f_min1, f_max1), (f_min2, f_max2)) =
-    (min(f_min1, f_min2), max(f_max1, f_max2))
-@inline unrolled_extrema(itr) = unrolled_extrema(identity, itr)
-@inline unrolled_extrema(f::F, itr) where {F} =
-    unrolled_mapreduce(extrema_reduction_operator, itr) do item
-        @inline
-        f_value = f(item)
-        (f_value, f_value)
-    end
-
-@inline findmax_reduction_operator((f_value1, value1), (f_value2, value2)) =
-    f_value1 < f_value2 ? (f_value2, value2) : (f_value1, value1)
-@inline unrolled_findmax(itr) = unrolled_findmax(identity, itr)
-@inline unrolled_findmax(f::F, itr) where {F} =
-    unrolled_mapreduce(findmax_reduction_operator, enumerate(itr)) do (n, item)
-        @inline
-        (f(item), n)
-    end
-
-@inline findmin_reduction_operator((f_value1, value1), (f_value2, value2)) =
-    f_value1 > f_value2 ? (f_value2, value2) : (f_value1, value1)
-@inline unrolled_findmin(itr) = unrolled_findmin(identity, itr)
-@inline unrolled_findmin(f::F, itr) where {F} =
-    unrolled_mapreduce(findmin_reduction_operator, enumerate(itr)) do (n, item)
-        @inline
-        (f(item), n)
-    end
-
-@inline unrolled_argmax(itr) = unrolled_findmax(itr)[2]
-@inline unrolled_argmax(f::F, itr) where {F} =
-    unrolled_mapreduce(findmax_reduction_operator, itr) do item
-        @inline
-        (f(item), item)
-    end[2]
-
-@inline unrolled_argmin(itr) = unrolled_findmin(itr)[2]
-@inline unrolled_argmin(f::F, itr) where {F} =
-    unrolled_mapreduce(findmin_reduction_operator, itr) do item
-        @inline
-        (f(item), item)
-    end[2]
-
-##
-## Unrolled analogues of functions from base/arrays.jl
-##
-
-@inline unrolled_findfirst(itr) = unrolled_findfirst(identity, itr)
-@inline unrolled_findfirst(f::F, itr) where {F} =
-    unrolled_ifelse(f, identity, Returns(nothing), itr, static_range(itr))
-
-@inline unrolled_findlast(itr) = unrolled_findlast(identity, itr)
-@inline unrolled_findlast(f::F, itr) where {F} = unrolled_ifelse(
-    f,
-    identity,
-    Returns(nothing),
-    Iterators.reverse(itr),
-    Iterators.reverse(static_range(itr)),
-)
-
-@inline unrolled_argfirst(f::F, itr) where {F} = unrolled_ifelse(
-    f,
-    identity,
-    () -> error("itr does not contain any items for which f(item) is true"),
-    itr,
-)
-
-@inline unrolled_arglast(f::F, itr) where {F} =
-    unrolled_argfirst(f, Iterators.reverse(itr))
 
 @inline unrolled_filter(f::F, itr) where {F} =
     unrolled_reduce(itr, inferred_empty(itr)) do items_with_true_f, item
@@ -380,53 +161,33 @@ include("generatively_unrolled_functions.jl")
         (items_with_true_f, unrolled_push(items_with_false_f, item))
     end
 
-##
-## Unrolled analogues of functions from base/iterators.jl
-##
-
 @inline unrolled_flatten(itr) =
-    if isempty(itr)
-        inferred_empty(itr)
-    elseif length(itr) == 1
-        non_lazy_iterator(generic_getindex(itr, 1))
-    else
-        unrolled_reduce(unrolled_append, itr)
-    end
+    unrolled_reduce(unrolled_append, itr, promoted_empty(itr))
 
 @inline unrolled_flatmap(f::F, itrs...) where {F} =
     unrolled_flatten(unrolled_map(f, itrs...))
 
 @inline unrolled_product(itrs...) =
-    ntuple(Val(unrolled_prod(length, itrs))) do n
+    unrolled_reduce(itrs, (promoted_empty(itrs),)) do product_itr, itr
         @inline
-        items = ntuple(Val(length(itrs))) do itr_index
+        unrolled_flatmap(itr) do item
             @inline
-            cur_length = length(itrs[itr_index])
-            prev_length = unrolled_prod(length, itrs[1:(itr_index - 1)])
-            item_index = (n - 1) ÷ prev_length % cur_length + 1
-            generic_getindex(itrs[itr_index], item_index)
+            unrolled_map_into_tuple(Base.Fix2(unrolled_push, item), product_itr)
         end
-        # Since the iterators are passed as individual arguments, the number of
-        # items is limited by the number of argument registers, so we can just
-        # use constructor_from_tuple and avoid sacrificing compilation time to
-        # optimize for low-storage iterators (e.g., by using unrolled_push).
-        constructor_from_tuple(promoted_output_type(itrs...))(items)
     end
 
-@inline unrolled_cycle(itr, ::Val{N}) where {N} =
-    unrolled_flatten(ntuple(Returns(itr), Val(N)))
+abstract type StaticSequence{N} end
 
-@inline unrolled_partition(itr, ::Val{N}) where {N} =
-    ntuple(Val(cld(length(itr), N))) do partition_number
-        @inline
-        first_index = N * (partition_number - 1)
-        last_index = min(length(itr), N * partition_number)
-        unrolled_drop(unrolled_take(itr, Val(last_index)), Val(first_index))
-    end
+@inline Base.length(::StaticSequence{N}) where {N} = N
+@inline Base.firstindex(::StaticSequence) = 1
+@inline Base.lastindex(itr::StaticSequence) = length(itr)
+@inline Base.getindex(itr::StaticSequence, n::Integer) =
+    generic_getindex(itr, n)
+@inline Base.iterate(itr::StaticSequence, n = 1) =
+    n > length(itr) ? nothing : (generic_getindex(itr, n), n + 1)
 
-##
-## Additional instructions for compilation
-##
+include("StaticOneTo.jl")
+include("StaticBitVector.jl")
 
 # Remove the default recursion limit from every function defined in this module.
 @static if hasfield(Method, :recursion_relation)

--- a/src/generatively_unrolled_functions.jl
+++ b/src/generatively_unrolled_functions.jl
@@ -1,9 +1,3 @@
-@generated _gen_unrolled_map(::Val{N}, f, itr) where {N} = quote
-    @inline
-    return Base.Cartesian.@ntuple $N n -> f(generic_getindex(itr, n))
-end
-@inline gen_unrolled_map(f, itr) = _gen_unrolled_map(Val(length(itr)), f, itr)
-
 @generated _gen_unrolled_any(::Val{N}, f, itr) where {N} = quote
     @inline
     return Base.Cartesian.@nany $N n -> f(generic_getindex(itr, n))
@@ -24,55 +18,71 @@ end
 @inline gen_unrolled_foreach(f, itr) =
     _gen_unrolled_foreach(Val(length(itr)), f, itr)
 
+@generated _gen_unrolled_map(::Val{N}, f, itr) where {N} = quote
+    @inline
+    return Base.Cartesian.@ntuple $N n -> f(generic_getindex(itr, n))
+end
+@inline gen_unrolled_map(f, itr) = _gen_unrolled_map(Val(length(itr)), f, itr)
+
+@generated _gen_unrolled_applyat(::Val{N}, f, n′, itr) where {N} = quote
+    @inline
+    Base.Cartesian.@nexprs $N n ->
+        (n′ == n && return f(generic_getindex(itr, n)))
+    unrolled_applyat_bounds_error()
+end # This is optimized into a switch instruction during LLVM code generation.
+@inline gen_unrolled_applyat(f, n, itr) =
+    _gen_unrolled_applyat(Val(length(itr)), f, n, itr)
+
 @generated _gen_unrolled_reduce(::Val{N}, op, itr, init) where {N} = quote
     @inline
-    $N == 0 && return init
-    first_itr_item = generic_getindex(itr, 1)
-    value_1 = init isa NoInit ? first_itr_item : op(init, first_itr_item)
-    Base.Cartesian.@nexprs $(N - 1) n ->
+    value_0 = init
+    $N == 0 && return value_0
+    return Base.Cartesian.@nexprs $N n ->
+        (value_n = op(value_{n - 1}, generic_getindex(itr, n)))
+end
+@generated _gen_unrolled_reduce(::Val{N}, op, itr, ::NoInit) where {N} = quote
+    @inline
+    value_1 = generic_getindex(itr, 1)
+    $N == 1 && return value_1
+    return Base.Cartesian.@nexprs $(N - 1) n ->
         (value_{n + 1} = op(value_n, generic_getindex(itr, n + 1)))
-    return $(Symbol(:value_, N))
 end
 @inline gen_unrolled_reduce(op, itr, init) =
     _gen_unrolled_reduce(Val(length(itr)), op, itr, init)
 
-@generated _gen_unrolled_accumulate(::Val{N}, op, itr, init) where {N} = quote
+@generated _gen_unrolled_accumulate(
+    ::Val{N},
+    op,
+    itr,
+    init,
+    transform,
+) where {N} = quote
     @inline
     $N == 0 && return ()
     first_itr_item = generic_getindex(itr, 1)
     value_1 = init isa NoInit ? first_itr_item : op(init, first_itr_item)
     Base.Cartesian.@nexprs $(N - 1) n ->
         (value_{n + 1} = op(value_n, generic_getindex(itr, n + 1)))
-    return Base.Cartesian.@ntuple $N n -> value_n
+    return Base.Cartesian.@ntuple $N n -> transform(value_n)
 end
-@inline gen_unrolled_accumulate(op, itr, init) =
-    _gen_unrolled_accumulate(Val(length(itr)), op, itr, init)
+@inline gen_unrolled_accumulate(op, itr, init, transform) =
+    _gen_unrolled_accumulate(Val(length(itr)), op, itr, init, transform)
 
-@generated _gen_unrolled_ifelse(::Val{N}, f, get_if, get_else, itr) where {N} =
-    quote
-        @inline
-        Base.Cartesian.@nexprs $N n -> begin
-            item = generic_getindex(itr, n)
-            f(item) && return get_if(item)
-        end
-        return get_else()
+# TODO: The following is experimental and will likely be removed in the future.
+# For some reason, combining these two methods into one (or combining them with
+# the method for gen_unrolled_reduce defined above) causes compilation of the
+# non-orographic gravity wave parametrization test in ClimaAtmos to hang.
+# Wrapping the first method's result in a block and adding an inline annotation
+# also causes compilation to hang. Even using the assignment form of the first
+# method definition below (as opposed to the function syntax used here) causes
+# it to hang. This has not yet been replicated in a minimal working example.
+@generated function val_unrolled_reduce(op, ::Val{N}, init) where {N}
+    return foldl((:init, 1:N...)) do prev_op_expr, item_expr
+        :(op($prev_op_expr, $item_expr))
     end
-@inline gen_unrolled_ifelse(f, get_if, get_else, itr) =
-    _gen_unrolled_ifelse(Val(length(itr)), f, get_if, get_else, itr)
-
-@generated _gen_unrolled_ifelse2(
-    ::Val{N},
-    f,
-    get_if,
-    get_else,
-    itr1,
-    itr2,
-) where {N} = quote
-    @inline
-    Base.Cartesian.@nexprs $N n -> begin
-        f(generic_getindex(itr1, n)) && return get_if(generic_getindex(itr2, n))
-    end
-    return get_else()
 end
-@inline gen_unrolled_ifelse(f, get_if, get_else, itr1, itr2) =
-    _gen_unrolled_ifelse2(Val(length(itr1)), f, get_if, get_else, itr1, itr2)
+@generated val_unrolled_reduce(op, ::Val{N}, ::NoInit) where {N} = Expr(
+    :block,
+    Expr(:meta, :inline),
+    foldl((op_expr, item_expr) -> :(op($op_expr, $item_expr)), 1:N),
+)

--- a/src/recursively_unrolled_functions.jl
+++ b/src/recursively_unrolled_functions.jl
@@ -1,11 +1,3 @@
-# TODO: Replace all of these with manually unrolled functions, which should be
-# faster to compile. That is the pattern used in Base for ntuple, map, etc.
-
-@inline _rec_unrolled_map(f) = ()
-@inline _rec_unrolled_map(f, item, items...) =
-    (f(item), _rec_unrolled_map(f, items...)...)
-@inline rec_unrolled_map(f, itr) = _rec_unrolled_map(f, itr...)
-
 @inline _rec_unrolled_any(f) = false
 @inline _rec_unrolled_any(f, item, items...) =
     f(item) || _rec_unrolled_any(f, items...)
@@ -21,6 +13,16 @@
     (f(item); _rec_unrolled_foreach(f, items...))
 @inline rec_unrolled_foreach(f, itr) = _rec_unrolled_foreach(f, itr...)
 
+@inline _rec_unrolled_map(f) = ()
+@inline _rec_unrolled_map(f, item, items...) =
+    (f(item), _rec_unrolled_map(f, items...)...)
+@inline rec_unrolled_map(f, itr) = _rec_unrolled_map(f, itr...)
+
+@inline _rec_unrolled_applyat(f, offset_n) = unrolled_applyat_bounds_error()
+@inline _rec_unrolled_applyat(f, offset_n, item, items...) =
+    offset_n == 1 ? f(item) : _rec_unrolled_applyat(f, offset_n - 1, items...)
+@inline rec_unrolled_applyat(f, n, itr) = _rec_unrolled_applyat(f, n, itr...)
+
 @inline _rec_unrolled_reduce(op, prev_value) = prev_value
 @inline _rec_unrolled_reduce(op, prev_value, item, items...) =
     _rec_unrolled_reduce(op, op(prev_value, item), items...)
@@ -28,36 +30,18 @@
     init isa NoInit ? _rec_unrolled_reduce(op, itr...) :
     _rec_unrolled_reduce(op, init, itr...)
 
-@inline _rec_unrolled_accumulate(op, prev_value) = (prev_value,)
-@inline _rec_unrolled_accumulate(op, prev_value, item, items...) = (
-    prev_value,
-    _rec_unrolled_accumulate(op, op(prev_value, item), items...)...,
+@inline _rec_unrolled_accumulate(op, transform, prev_value) =
+    (transform(prev_value),)
+@inline _rec_unrolled_accumulate(op, transform, prev_value, item, items...) = (
+    transform(prev_value),
+    _rec_unrolled_accumulate(op, transform, op(prev_value, item), items...)...,
 )
-@inline rec_unrolled_accumulate(op, itr, init) =
+@inline rec_unrolled_accumulate(op, itr, init, transform) =
     isempty(itr) ? () :
-    init isa NoInit ? _rec_unrolled_accumulate(op, itr...) :
+    init isa NoInit ? _rec_unrolled_accumulate(op, transform, itr...) :
     _rec_unrolled_accumulate(
         op,
+        transform,
         op(init, generic_getindex(itr, 1)),
         unrolled_drop(itr, Val(1))...,
     )
-
-@inline _rec_unrolled_ifelse(f, get_if, get_else) = get_else()
-@inline _rec_unrolled_ifelse(f, get_if, get_else, item, items...) =
-    f(item) ? get_if(item) : _rec_unrolled_ifelse(f, get_if, get_else, items...)
-@inline rec_unrolled_ifelse(f, get_if, get_else, itr) =
-    _rec_unrolled_ifelse(f, get_if, get_else, itr...)
-
-@inline _rec_unrolled_ifelse2(f, get_if, get_else) = get_else()
-@inline _rec_unrolled_ifelse2(f, get_if, get_else, (item1, item2), items...) =
-    f(item1) ? get_if(item2) :
-    _rec_unrolled_ifelse2(f, get_if, get_else, items...)
-@inline rec_unrolled_ifelse(f, get_if, get_else, itr1, itr2) =
-    _rec_unrolled_ifelse2(f, get_if, get_else, _unrolled_zip(itr1, itr2)...)
-# Using zip here triggers the recursion limit for one unit test on Julia 1.10.
-
-@inline _unrolled_zip(itr1, itr2) =
-    ntuple(Val(min(length(itr1), length(itr2)))) do n
-        @inline
-        (generic_getindex(itr1, n), generic_getindex(itr2, n))
-    end


### PR DESCRIPTION
This PR reverts ClimaUtilities to 0.1.6, as this was the last version that worked with ClimaCore.

We can re-apply #20, #21, and #22 (while ensuring that the downstream tests are passing).

This way we don't block people from working on their tasks.