### PR TITLE
Add unrolled_mapcall function

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -89,6 +89,7 @@ iterators (in terms of both performance and compilation time):
 
 In addition, this package exports several functions that do not have analogues
 in `Base` or `Base.Iterators`:
+- `unrolled_mapcall(f, op, itrs...)`—similar to `op(map(f, itrs...)...)`
 - `unrolled_applyat(f, n, itrs...)`—similar to `f(itrs[1][n], itrs[2][n], ...)`
 - `unrolled_argfirst(f, itr)`—similar to `itr[findfirst(f, itr)]`
 - `unrolled_arglast(f, itr)`—similar to `itr[findlast(f, itr)]`

--- a/src/manually_unrolled_functions.jl
+++ b/src/manually_unrolled_functions.jl
@@ -1,14 +1,15 @@
-@inline _unrolled_map(::Val{0}, f, itr) = ()
-@inline _unrolled_map(::Val{1}, f, itr) = (f(generic_getindex(itr, 1)),)
-@inline _unrolled_map(::Val{2}, f, itr) =
-    (f(generic_getindex(itr, 1)), f(generic_getindex(itr, 2)))
-@inline _unrolled_map(::Val{3}, f, itr) = (
+@inline _unrolled_mapcall(::Val{0}, f, op, itr) = op()
+@inline _unrolled_mapcall(::Val{1}, f, op, itr) =
+    op(f(generic_getindex(itr, 1)))
+@inline _unrolled_mapcall(::Val{2}, f, op, itr) =
+    op(f(generic_getindex(itr, 1)), f(generic_getindex(itr, 2)))
+@inline _unrolled_mapcall(::Val{3}, f, op, itr) = op(
     f(generic_getindex(itr, 1)),
     f(generic_getindex(itr, 2)),
     f(generic_getindex(itr, 3)),
 )
-@generated _unrolled_map(::Val{N}, f, itr) where {N} =
-    :(@inline Base.Cartesian.@ntuple $N n -> f(generic_getindex(itr, n)))
+@generated _unrolled_mapcall(::Val{N}, f, op, itr) where {N} =
+    :(@inline Base.Cartesian.@ncall $N op n -> f(generic_getindex(itr, n)))
 
 @inline _unrolled_any(::Val{0}, f, itr) = false
 @inline _unrolled_any(::Val{1}, f, itr) = f(generic_getindex(itr, 1))

--- a/src/unrollable_iterator_interface.jl
+++ b/src/unrollable_iterator_interface.jl
@@ -136,8 +136,8 @@ end
         first_item_type(generic_getindex(itrs, 1))
     end
 
-@inline unrolled_map_output_type(f, itr) =
-    inferred_output_type(Iterators.map(f, itr))
+@inline unrolled_map_output_type(f, itrs...) =
+    inferred_output_type(Iterators.map(f, itrs...))
 
 @inline unrolled_accumulate_output_type(op, itr, init) =
     unambiguous_output_type(output_type_for_promotion(itr)) do

--- a/test/recursively_unrolled_functions.jl
+++ b/test/recursively_unrolled_functions.jl
@@ -3,7 +3,7 @@ using UnrolledUtilities: NoInit, generic_getindex, unrolled_drop
 @inline _rec_unrolled_map(f) = ()
 @inline _rec_unrolled_map(f, item, items...) =
     (f(item), _rec_unrolled_map(f, items...)...)
-@inline rec_unrolled_map(f, itr) = _rec_unrolled_map(f, itr...)
+@inline rec_unrolled_mapcall(f, op, itr) = op(_rec_unrolled_map(f, itr...)...)
 
 @inline _rec_unrolled_any(f) = false
 @inline _rec_unrolled_any(f, item, items...) =

--- a/test/test_and_analyze.jl
+++ b/test/test_and_analyze.jl
@@ -523,6 +523,15 @@ for itr in (
             str,
         )
 
+        if length(itr) <= 32
+            @test_unrolled(
+                (itr,),
+                unrolled_mapcall(length, +, itr),
+                +(map(length, itr)...),
+                str,
+            )
+        end # + is only type-stable up to 32 arguments
+
         @test_unrolled (itr,) unrolled_map(length, itr) map(length, itr) str
 
         @test_unrolled (itr,) unrolled_any(isempty, itr) any(isempty, itr) str
@@ -1139,15 +1148,27 @@ for itr in (
     str = tuples_of_tuples_contents_str(itr)
     itr_description = "a Tuple that contains $(length(itr)) $str"
     @testset "manual vs. recursive unrolling of $itr_description" begin
+        if length(itr) <= 32
+            @test_unrolled(
+                (itr,),
+                unrolled_mapcall(length, +, itr),
+                rec_unrolled_mapcall(length, +, itr),
+                str,
+                false,
+                false,
+                true,
+            )
+        end # + is only type-stable up to 32 arguments
+
         @test_unrolled(
             (itr,),
-            UnrolledUtilities.unrolled_map_into_tuple(length, itr),
-            rec_unrolled_map(length, itr),
+            unrolled_mapcall(length, tuple, itr),
+            rec_unrolled_mapcall(length, tuple, itr),
             str,
             false,
             false,
             true,
-        )
+        ) # unrolled_map(length, itr)
 
         @test_unrolled(
             (itr,),


### PR DESCRIPTION
This PR adds a functional form of `Base.Cartesian.@ncall` to UnrolledUtilities: `unrolled_mapcall(f, op, itrs...)`, which is roughly equivalent to `op(unrolled_map(f, itrs...)...)`. This function reduces compilation time by manually splatting the arguments of `op` into a function call instead of relying on the compiler to infer and inline the result of `Core._apply_iterate(Base.iterate, op, unrolled_map(f, itrs...))`. @charleskawczynski's work in CliMA/ClimaCore.jl#2225 has shown that this change and the changes in #25 could allow us to reduce the latency of ClimaCore broadcast expressions.

**Note**: This PR is split off from #25, so it currently includes both sets of changes. Once that PR is merged in, this one should be rebased.